### PR TITLE
Delete REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.0
-ImageCore 0.7.4


### PR DESCRIPTION
`REQUIRE` is no longer needed for the new package registrator and CI