### PR TITLE
strip tuple wrapper to speed up centroid calc

### DIFF
--- a/src/connected.jl
+++ b/src/connected.jl
@@ -274,10 +274,12 @@ end
 "`component_centroids(labeled_array)` -> an array of centroids for each label, including the background label 0"
 function component_centroids(img::AbstractArray{Int,N}) where N
     len = length(0:maximum(img))
-    n = fill((zero(CartesianIndex{N}), 0), len)
+    n = fill(zero(CartesianIndex{N}), len)
+    counts = fill(0, len)
     @inbounds for I in CartesianIndices(size(img))
         v = img[I] + 1
-        n[v] = n[v] .+ (I, 1)
+        n[v] += I
+        counts[v] += 1
     end
-    map(v -> n[v][1].I ./ n[v][2], 1:len)
+    map(v -> n[v].I ./ counts[v], 1:len)
 end


### PR DESCRIPTION
continuation of https://github.com/JuliaImages/Images.jl/pull/810

https://github.com/JuliaLang/julia/issues/28980 seems unrelated because the 100x fold regression is fixed on master but this PR still yields about a 10% increase in median speed:

### Images master
```julia
julia> a = rand(0:250, 1024, 1024);

julia> @benchmark Images.component_centroids(a)
BenchmarkTools.Trial: 
  memory estimate:  10.17 KiB
  allocs estimate:  4
  --------------
  minimum time:     1.972 ms (0.00% GC)
  median time:      2.748 ms (0.00% GC)
  mean time:        2.742 ms (0.00% GC)
  maximum time:     5.276 ms (0.00% GC)
  --------------
  samples:          1819
  evals/sample:     1
```

### This PR

```julia
julia> @benchmark Images.component_centroids(a)
BenchmarkTools.Trial: 
  memory estimate:  10.31 KiB
  allocs estimate:  5
  --------------
  minimum time:     1.907 ms (0.00% GC)
  median time:      2.498 ms (0.00% GC)
  mean time:        2.489 ms (0.00% GC)
  maximum time:     3.595 ms (0.00% GC)
  --------------
  samples:          2000
  evals/sample:     1

julia> println(VERSION)
1.3.0-DEV.320
```