### PR TITLE
fix jldoctest error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,13 +10,15 @@ TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 
 [compat]
 ColorVectorSpace = "0.7, 0.8"
+Documenter = "0.24, 0.25"
 ImageCore = "0.8.1"
 TiledIteration = "0.2"
 julia = "1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OffsetArrays", "Test"]
+test = ["Documenter", "OffsetArrays", "Test"]

--- a/src/maxtree.jl
+++ b/src/maxtree.jl
@@ -251,7 +251,7 @@ Constructs the *max-tree* of the `image`.
 # Examples
 We create a small sample image (Figure 1 from [4]) and build the max-tree.
 
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> image = [15 13 16; 12 12 10; 16 12 14]
 3×3 Array{Int64,2}:
  15  13  16
@@ -490,15 +490,16 @@ An array of the same type and shape as the `image`.
 # Examples
 Creating a test image `f` (quadratic function with a maximum in the center and
 4 additional local maxima):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 12;
+
 julia> f = [20 - 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:4, 2:6] .= 40; f[3:5, 10:12] .= 60; f[10:12, 3:5] .= 80;
+
 julia> f[10:11, 10:12] .= 100; f[11, 11] = 100;
-```
-Area opening of `f`:
-```jldoctest
-julia> f_aopen = area_opening(f, min_area=8, connectivity=1)
+
+julia> f_aopen = area_opening(f, min_area=8, connectivity=1);
 ```
 The peaks with a surface smaller than 8 are removed.
 """
@@ -560,15 +561,16 @@ An array of the same type and shape as the `image`.
 # Examples
 Creating a test image `f` (quadratic function with a maximum in the center and
 4 additional local maxima):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 12;
+
 julia> f = [20 - 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:4, 2:6] .= 40; f[3:5, 10:12] .= 60; f[10:12, 3:5] .= 80;
+
 julia> f[10:11, 10:12] .= 100; f[11, 11] = 100;
-```
-Diameter opening of `f`:
-```jldoctest
-julia> f_dopen = diameter_opening(f, min_diameter=3, connectivity=1)
+
+julia> f_dopen = diameter_opening(f, min_diameter=3, connectivity=1);
 ```
 The peaks with a maximal diameter of 2 or less are removed.
 For the remaining peaks the widest side of the bounding box is at least 3.
@@ -641,15 +643,16 @@ An array of the same type and shape as the `image`.
 # Examples
 Creating a test image `f` (quadratic function with a minimum in the center and
 4 additional local minima):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 12;
+
 julia> f = [180 + 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:4, 2:6] .= 40; f[3:5, 10:12] .= 60; f[10:12, 3:5] .= 80;
+
 julia> f[10:11, 10:12] .= 100; f[11, 11] = 100;
-```
-Area closing of `f`:
-```jldoctest
-julia> f_aclose = area_closing(f, min_area=8, connectivity=1)
+
+julia> f_aclose = area_closing(f, min_area=8, connectivity=1);
 ```
 All small minima are removed, and the remaining minima have at least
 a size of 8.
@@ -708,15 +711,16 @@ An array of the same type and shape as the `image`.
 # Examples
 Creating a test image `f` (quadratic function with a minimum in the center and
 4 additional local minima):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 12;
+
 julia> f = [180 + 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:4, 2:6] .= 40; f[3:5, 10:12] .= 60; f[10:12, 3:5] .= 80;
+
 julia> f[10:11, 10:12] .= 100; f[11, 11] = 100;
-```
-Area closing of `f`:
-```jldoctest
-julia> f_dclose = diameter_closing(f, min_diameter=3, connectivity=1)
+
+julia> f_dclose = diameter_closing(f, min_diameter=3, connectivity=1);
 ```
 All small minima with a diameter of 2 or less are removed.
 For the remaining minima the widest bounding box side is at least 3.
@@ -811,14 +815,14 @@ value (the local maximum id).
 # Examples
 Create `f` (quadratic function with a maximum in the center and
 4 additional constant maxima):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 10;
+
 julia> f = [20 - 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:5, 3:5] .= 40; f[3:5, 8:10] .= 60; f[8:10, 3:5] .= 80; f[8:10, 8:10] .= 100;
-```
-Get all local maxima of ``f``:
-```jldoctest
-julia> f_maxima = local_maxima(f)
+
+julia> f_maxima = local_maxima(f); # Get all local maxima of `f`
 ```
 The resulting image contains the 4 labeled local maxima.
 """
@@ -871,14 +875,14 @@ value (the local minimum id).
 # Examples
 Create `f` (quadratic function with a minimum in the center and
 4 additional constant minimum):
-```jldoctest
+```jldoctest; setup = :(using ImageMorphology)
 julia> w = 10;
+
 julia> f = [180 + 0.2*((x - w/2)^2 + (y-w/2)^2) for x in 0:w, y in 0:w];
+
 julia> f[3:5, 3:5] .= 40; f[3:5, 8:10] .= 60; f[8:10, 3:5] .= 80; f[8:10, 8:10] .= 100;
-```
-Calculate all local minima of `f`:
-```jldoctest
-julia> f_minima = local_minima(f)
+
+julia> f_minima = local_minima(f); # Calculate all local minima of `f`
 ```
 The resulting image contains the labeled local minima.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using ImageCore
 using Test
 using OffsetArrays
 
+using Documenter
+doctest(ImageMorphology, manual = false)
+
 @testset "ImageMorphology" begin
     include("convexhull.jl")
     include("connected.jl")


### PR DESCRIPTION
There're a lot of doctest warnings when building the juliaimages documentation, and this PR fix that

It would be better to provide some simpler examples with their results as test references, but since it is 19*19 matrix (pretty large), I didn't modify that.

log: https://travis-ci.org/github/JuliaImages/juliaimages.github.io/builds/703805289