### PR TITLE
Transfer support for ImageMeta

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:

--- a/Project.toml
+++ b/Project.toml
@@ -5,18 +5,21 @@ version = "0.2.12"
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 
 [compat]
 Documenter = "0.24, 0.25"
 ImageCore = "0.9"
+Requires = "1"
 TiledIteration = "0.2, 0.3"
 julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "OffsetArrays", "Test"]
+test = ["Documenter", "ImageMetadata", "OffsetArrays", "Test"]

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -5,6 +5,7 @@ using ImageCore: GenericGrayImage
 using LinearAlgebra
 using Base.Cartesian # TODO: delete this
 using TiledIteration: EdgeIterator
+using Requires
 
 include("convexhull.jl")
 include("connected.jl")
@@ -58,5 +59,13 @@ export
     distance_transform,
 
     clearborder
+
+function __init__()
+    @require ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
+        # morphological operations for ImageMeta
+        dilate(img::ImageMetadata.ImageMeta, region=coords_spatial(img)) = ImageMetadata.shareproperties(img, dilate!(copy(ImageMetadata.arraydata(img)), region))
+        erode(img::ImageMetadata.ImageMeta, region=coords_spatial(img)) = ImageMetadata.shareproperties(img, erode!(copy(ImageMetadata.arraydata(img)), region))
+    end
+end
 
 end # module

--- a/test/dilation_and_erosion.jl
+++ b/test/dilation_and_erosion.jl
@@ -26,6 +26,11 @@
         @test Ae == cat(Ar, Ag, zeros(4,4), dims=3)
         # issue Images.jl #311
         @test dilate(trues(3)) == trues(3)
+        # ImageMeta
+        @test arraydata(dilate(ImageMeta(A))) == dilate(A)
+        @test arraydata(dilate(ImageMeta(A), 1:2)) == dilate(A, 1:2)
+        @test arraydata(erode(ImageMeta(A))) == erode(A)
+        @test arraydata(erode(ImageMeta(A), 1:2)) == erode(A, 1:2)
     end
 
     @testset "Opening / closing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using ImageMorphology
 using ImageCore
 using Test
 using OffsetArrays
+using ImageMetadata
+
 
 using Documenter
 doctest(ImageMorphology, manual = false)


### PR DESCRIPTION
This came from Images.jl and is part of the code clean-out making
Images.jl mostly a "meta-package." It's also better to put glue
functionality in one of the packages that defines the components,
since that ensures that the glue-code is always available whenever
the operation can be supported.

xref https://github.com/JuliaImages/Images.jl/pull/971