### PR TITLE
Modernize `label_components`

### DIFF
--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -18,6 +18,8 @@ include("maxtree.jl")
 include("bwdist.jl")
 using .FeatureTransform
 
+include("deprecations.jl")
+
 export
     dilate,
     dilate!,

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -101,8 +101,8 @@ function half_diamond(A::AbstractArray{T,N}, dims) where {T,N}
             push!(offsets, CartesianIndex(ntuple(i -> i == d ? -1 : 0, N)))
         end
     end
-    # return (offsets...,)   # returning as a tuple allows specialization
-    return offsets
+    return (offsets...,)   # returning as a tuple allows specialization
+    # return offsets
 end
 half_diamond(A::AbstractArray{T,N}, ::Colon) where {T,N} = half_diamond(A, 1:N)
 
@@ -121,8 +121,8 @@ function half_pattern(A::AbstractArray{T,N}, connectivity::AbstractArray{Bool}) 
             push!(offsets, i - center)
         end
     end
-    return offsets
-    # return (offsets...,)   # returning as a tuple allows specialization
+    # return offsets
+    return (offsets...,)   # returning as a tuple allows specialization
 end
 
 # Copied directly from DataStructures.jl, but specialized

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,6 @@
+@deprecate label_components(A::AbstractArray, region::Union{Dims, AbstractVector{Int64}}, bkg = 0) label_components(A; bkg=bkg, dims=region)
+@deprecate label_components(A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}   label_components(A, connectivity; bkg=bkg)
+@deprecate label_components!(out::AbstractArray{Int}, A::AbstractArray, region::Union{Dims, AbstractVector{Int64}}, bkg = 0)  label_components!(out, A; bkg=bkg, dims=region)
+@deprecate label_components!(out::AbstractArray{Int,N}, A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}  label_components!(out, A, connectivity; bkg=bkg)
+
+@deprecate imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, dims::Union{Dims, AbstractVector{Int}}) imfill(img, interval; dims=dims)

--- a/src/imfill.jl
+++ b/src/imfill.jl
@@ -14,14 +14,32 @@ Parameters:
 # Examples
 
 ```jldoctest; setup=:(using ImageMorphology)
+julia> img = Bool[0 0 1 1 0 0;
+                  0 1 0 1 1 0;
+                  0 0 1 1 0 0]
+3×6 Matrix{Bool}:
+ 0  0  1  1  0  0
+ 0  1  0  1  1  0
+ 0  0  1  1  0  0
 
+julia> imfill(.!(img), 0:3)
+3×6 BitMatrix:
+ 1  1  0  0  1  1
+ 1  0  0  0  0  1
+ 1  1  0  0  1  1
+
+julia> .!(ans)
+3×6 BitMatrix:
+ 0  0  1  1  0  0
+ 0  1  1  1  1  0
+ 0  0  1  1  0  0
 ```
 """
 imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, connectivity::AbstractArray{Bool}) =
     _imfill(img, interval, label_components(img,connectivity))
 imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}; dims=coords_spatial(img)) =
     _imfill(img, interval, label_components(img; dims=dims))
-imfill(img::AbstractArray{Bool}, interval, args; kwargs...) =
+imfill(img::AbstractArray{Bool}, interval, args...; kwargs...) =
     imfill(img, (minimum(interval)::Real, maximum(interval)::Real), args...; kwargs...)
 
 function _imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, labels)

--- a/src/imfill.jl
+++ b/src/imfill.jl
@@ -1,33 +1,33 @@
 """
- Image filling Algorithm
+    filled_img = imfill(img::AbstractArray{Bool}, interval; dims=coords_spatial(img))
+    filled_img = imfill(img::AbstractArray{Bool}, interval, connectivity)
 
- ```
- filled_img = imfill(img, interval)
- filled_img = imfill(img, interval, value)
- filled_img = imfill(img, interval, value, connectivity)
- ```
+Connected components of an image is found using flood-fill algorithm and returns a copy of
+the original image after filling objects that falls in the range of interval.
+For filling objects, represent the holes (part to be filled) with `true` in your array.
 
- Connected components of an image is found using flood-fill algorithm and returns a copy of
- the original image after filling objects that falls in the range of interval.
- For filling objects, represent the holes(part to be filled) with `true` in your array.
+Parameters:
+-  img            = Input image (Boolean array type)
+-  interval       = objects of size (# of voxels) in this range will be filled with `false`
+-  connectivity   = a Boolean-valued connectivity pattern, see [`label_components`](@ref).
 
+# Examples
 
- Parameters:
+```jldoctest; setup=:(using ImageMorphology)
 
-  -  img            = Input image (Boolean array type)
-  -  interval       = objects of size in this range will be filled with `false`
-  -  connectivity   = connectivity takes the same values as in label_components (Default value is 1:ndims(img))
+```
+"""
+imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, connectivity::AbstractArray{Bool}) =
+    _imfill(img, interval, label_components(img,connectivity))
+imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}; dims=coords_spatial(img)) =
+    _imfill(img, interval, label_components(img; dims=dims))
+imfill(img::AbstractArray{Bool}, interval, args; kwargs...) =
+    imfill(img, (minimum(interval)::Real, maximum(interval)::Real), args...; kwargs...)
 
- """
-
-function imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, connectivity::Union{Dims, AbstractVector{Int}, BitArray}=1:ndims(img))
-
+function _imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, labels)
     if interval[1] > interval[2] || interval[1] < 0 || interval[2] < 0
         throw(DomainError(interval,"Interval must be non-negative and in format (min_range,max_range)"))
     end
-
-    labels = label_components(img,connectivity)
-
     count_labels = component_lengths(labels)
 
     new_img = similar(img)

--- a/test/connected.jl
+++ b/test/connected.jl
@@ -6,7 +6,9 @@
     lbltarget1 = [1 2 0 4;
                   1 0 3 4]
     @test label_components(A) == lbltarget
-    @test label_components(A, [1]) == lbltarget1
+    @test label_components(A; dims=:) == lbltarget
+    @test label_components(A; dims=1) == lbltarget1
+    @test label_components(A, [1]) == lbltarget1     # deprecated
     connectivity = [false true  false;
                     true  false true;
                     false true  false]
@@ -20,4 +22,8 @@
     @test component_indices(lbltarget) == Array{Int64}[[4,5],[1,2,3],[6,7,8]]
     @test component_subscripts(lbltarget) == Array{Tuple}[[(2,2),(1,3)],[(1,1),(2,1),(1,2)],[(2,3),(1,4),(2,4)]]
     @test @inferred(component_centroids(lbltarget)) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
+
+    @test label_components!(zeros(UInt8, 240), trues(240); dims=()) == 1:240
+    @test_throws ErrorException("labels exhausted, use a larger integer type") label_components!(zeros(UInt8, 260), trues(260); dims=())
+    @test label_components!(zeros(UInt16, 260), trues(260); dims=()) == 1:260
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using ImageMetadata
 
 
 using Documenter
-doctest(ImageMorphology, manual = false)
+Base.VERSION >= v"1.6" && doctest(ImageMorphology, manual = false)
 
 @testset "ImageMorphology" begin
     include("convexhull.jl")


### PR DESCRIPTION
`label_components` is one of the more important algorithms here,
but it was written to a very old version of Julia and not substantially
updated since. This reworks it to a more modern approach.
From the user perspective, the biggest change is the switch to a kwarg
interface for `dims`.

Because `imfill` calls `label_components`, it too was reworked similarly.

Fixes #21