### PR TITLE
`feature_transform`: add multithreading

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', 'nightly']
+        julia-version: ['1.3', '1', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
         include:
@@ -44,6 +44,9 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - name: multithreading
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.julia-version == '1' }}
+        run: julia --project --code-coverage -t4 test/multithreaded.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 Documenter = "0.24, 0.25"
 ImageCore = "0.9"
 Requires = "1"
-TiledIteration = "0.2, 0.3"
-julia = "1"
+TiledIteration = "0.3.1"
+julia = "1.3"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -3,8 +3,7 @@ module ImageMorphology
 using ImageCore
 using ImageCore: GenericGrayImage
 using LinearAlgebra
-using Base.Cartesian # TODO: delete this
-using TiledIteration: EdgeIterator
+using TiledIteration: EdgeIterator, SplitAxis, SplitAxes
 using Requires
 
 include("convexhull.jl")

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -4,3 +4,6 @@
 @deprecate label_components!(out::AbstractArray{Int,N}, A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}  label_components!(out, A, connectivity; bkg=bkg)
 
 @deprecate imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, dims::Union{Dims, AbstractVector{Int}}) imfill(img, interval; dims=dims)
+
+import .FeatureTransform: feature_transform
+@deprecate feature_transform(img, weights; kwargs...) feature_transform(img; weights=weights, kwargs...)

--- a/test/bwdist.jl
+++ b/test/bwdist.jl
@@ -68,6 +68,8 @@
         @test F == ind2cart([1 1 1; 2 2 13; 2 8 13; 4 9 14; 4 10 10])
         D = distance_transform(F)
         @test D == [0.0 1.0 2.0; 0.0 1.0 1.0; 1.0 0.0 0.0; 0.0 0.0 0.0; 1.0 0.0 1.0]
+
+        @test feature_transform(Gray.(A)) == F
     end
 
     @testset "Corner Case Images" begin
@@ -128,6 +130,11 @@
         @test F == ind2cart(reshape(1:length(A), size(A)))
         D = distance_transform(F)
         @test all(x->x==0, D)
+
+        # (9)
+        A = falses(4,2,3)
+        A[3,1,2] = true
+        @test all(==(CartesianIndex(3,1,2)), feature_transform(A))
     end
 
     @testset "Anisotropic images" begin

--- a/test/multithreaded.jl
+++ b/test/multithreaded.jl
@@ -1,0 +1,16 @@
+# This doesn't run under "runtests.jl" but does under CI
+using ImageMorphology
+using Test
+
+@testset "multithreaded" begin
+    @test Threads.nthreads() > 1
+    @testset "feature_transform" begin
+        img = rand(100, 128) .> 0.9
+        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1)
+        # Since the threaded implementation handles two dimensions specially, we should check 0d and 1d
+        img = reshape([true])
+        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1) == reshape([CartesianIndex()])
+        img = rand(100) .> 0.9
+        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,3 +19,5 @@ Base.VERSION >= v"1.6" && doctest(ImageMorphology, manual = false)
     include("bwdist.jl")
     include("clearborder.jl")
 end
+
+# multithreaded.jl runs on CI


### PR DESCRIPTION
If Julia is being run with multiple threads, this now will default
to using all threads in `feature_transform`. The multithreaded
implementation is relatively straightforward, although the recursive algorithm
makes it a little hard to wrap your head around:

- `computeft!` for dimension `d` is dependent only on slices of dimensions `1:d`,
  and indeed for all except the final call to `voronoift!` just on dimensions `1:d-1`.
  Hence you can divide the last dimension `N` into chunks and give each to a thread.

- For the final `voronoift!` call along dimension `N`, it's a
  one-dimensional operation along this dimension. Hence you can just
  split the next-to-last dimension into chunks instead.

This change was responsible for performance improvements in `distance_transform`
noted in https://github.com/JuliaImages/image_benchmarks/issues/1.

I am unsure about the generalization to `Gray{Bool}`; Julia doesn't treat anything beside `Bool` as a bool in `if` statements, but OTOH when we load a "binary image" it comes in as `Gray{Bool}`. I'd be interested in the thoughts of others.