### PR TITLE
Fix Int vs Int64 issues

### DIFF
--- a/src/clearborder.jl
+++ b/src/clearborder.jl
@@ -26,7 +26,7 @@ function clearborder(img::AbstractArray, width::Integer=1, background::Integer=0
     outerrange = CartesianIndices(map(i -> 1:i, dimensions))
     innerrange = CartesianIndices(map(i -> 1+width:i-width, dimensions))
 
-    border_labels = Set{Int64}()
+    border_labels = Set{Int}()
     for i in EdgeIterator(outerrange,innerrange)
         push!(border_labels, labels[i])
     end

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -186,7 +186,7 @@ end
 "`component_boxes(labeled_array)` -> an array of bounding boxes for each label, including the background label 0"
 function component_boxes(img::AbstractArray{Int})
     nd = ndims(img)
-    n = [Vector{Int64}[ fill(typemax(Int64),nd), fill(typemin(Int64),nd) ]
+    n = [Vector{Int}[ fill(typemax(Int),nd), fill(typemin(Int),nd) ]
             for i=0:maximum(img)]
     s = CartesianIndices(size(img))
     for i=1:length(img)
@@ -203,7 +203,7 @@ end
 
 "`component_lengths(labeled_array)` -> an array of areas (2D), volumes (3D), etc. for each label, including the background label 0"
 function component_lengths(img::AbstractArray{Int})
-    n = zeros(Int64,maximum(img)+1)
+    n = zeros(Int,maximum(img)+1)
     for i=1:length(img)
         n[img[i]+1]+=1
     end
@@ -212,7 +212,7 @@ end
 
 "`component_indices(labeled_array)` -> an array of pixels for each label, including the background label 0"
 function component_indices(img::AbstractArray{Int})
-    n = [Int64[] for i=0:maximum(img)]
+    n = [Int[] for i=0:maximum(img)]
     for i=1:length(img)
       push!(n[img[i]+1],i)
     end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,6 +1,6 @@
-@deprecate label_components(A::AbstractArray, region::Union{Dims, AbstractVector{Int64}}, bkg = 0) label_components(A; bkg=bkg, dims=region)
+@deprecate label_components(A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0) label_components(A; bkg=bkg, dims=region)
 @deprecate label_components(A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}   label_components(A, connectivity; bkg=bkg)
-@deprecate label_components!(out::AbstractArray{Int}, A::AbstractArray, region::Union{Dims, AbstractVector{Int64}}, bkg = 0)  label_components!(out, A; bkg=bkg, dims=region)
+@deprecate label_components!(out::AbstractArray{Int}, A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0)  label_components!(out, A; bkg=bkg, dims=region)
 @deprecate label_components!(out::AbstractArray{Int,N}, A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}  label_components!(out, A, connectivity; bkg=bkg)
 
 @deprecate imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, dims::Union{Dims, AbstractVector{Int}}) imfill(img, interval; dims=dims)

--- a/src/maxtree.jl
+++ b/src/maxtree.jl
@@ -251,9 +251,9 @@ Constructs the *max-tree* of the `image`.
 # Examples
 We create a small sample image (Figure 1 from [4]) and build the max-tree.
 
-```jldoctest; setup = :(using ImageMorphology), filter = r"Array{Int64,2}|Matrix{Int64}"
+```jldoctest; setup = :(using ImageMorphology), filter = r"Array{$Int,2}|Matrix{$Int}"
 julia> image = [15 13 16; 12 12 10; 16 12 14]
-3×3 Array{Int64,2}:
+3×3 Array{$Int,2}:
  15  13  16
  12  12  10
  16  12  14

--- a/test/connected.jl
+++ b/test/connected.jl
@@ -19,7 +19,7 @@
     @test label_components(A, connectivity) == lbltarget2
     @test component_boxes(lbltarget) == Vector{Tuple}[[(1,2),(2,3)],[(1,1),(2,2)],[(1,3),(2,4)]]
     @test component_lengths(lbltarget) == [2,3,3]
-    @test component_indices(lbltarget) == Array{Int64}[[4,5],[1,2,3],[6,7,8]]
+    @test component_indices(lbltarget) == Array{Int}[[4,5],[1,2,3],[6,7,8]]
     @test component_subscripts(lbltarget) == Array{Tuple}[[(2,2),(1,3)],[(1,1),(2,1),(1,2)],[(2,3),(1,4),(2,4)]]
     @test @inferred(component_centroids(lbltarget)) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
 


### PR DESCRIPTION
There are several other cases of `Int64`, notably in `connected.jl`. Does anyone know if those are deliberate? Some people use `Int64` simply because they have a 64-bit computer, when they should be using `Int` instead.