### PR TITLE
[Morphology][Benchmarks] add first set of benchmarks one by "class" of algorithm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,30 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  Benchmark:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run benchmark')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add JSON BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia benchmark/run_benchmarks.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ImageBinarization = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageMorphology = "787d08f9-d448-5407-9aad-5290dd7ab264"
+ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,58 @@
+# Usage:
+#     julia benchmark/run_benchmarks.jl
+using BenchmarkTools
+using ImageCore
+using ImageMorphology
+using ImageBinarization
+using ImageTransformations
+using TestImages
+
+on_CI = haskey(ENV, "GITHUB_ACTIONS")
+
+cameraman = Gray{N0f8}.(testimage("cameraman"))
+blobs = binarize(Gray.(testimage("blobs")), Otsu()) .> 0.5
+
+tst_sizes = on_CI ? (64, ) : (256, 512)
+tst_types = (Gray{N0f8}, Gray{Float32})
+
+const SUITE = BenchmarkGroup()
+
+SUITE["dilatation_and_erosion"] = BenchmarkGroup()
+let grp = SUITE["dilatation_and_erosion"]
+    grp["erode"] = BenchmarkGroup()
+    grp["opening"] = BenchmarkGroup()
+    for T in tst_types
+        grp["erode"][T] = BenchmarkGroup()
+        grp["opening"][T] = BenchmarkGroup()
+        for sz in tst_sizes
+            tst_img = T.(imresize(T.(cameraman), (sz, sz)))
+            grp["erode"][T]["$sz×$sz"] = @benchmarkable erode($tst_img)
+            grp["opening"][T]["$sz×$sz"] = @benchmarkable opening($tst_img)
+        end
+    end
+end
+
+SUITE["connected"] = BenchmarkGroup()
+let grp = SUITE["connected"]
+    grp["label_components"] = @benchmarkable label_components($blobs)
+end
+
+SUITE["Maxtree"] = BenchmarkGroup()
+let grp = SUITE["Maxtree"]
+    grp["area_opening"] = BenchmarkGroup()
+    for sz in tst_sizes
+        tst_img = (imresize((cameraman), (sz, sz)))
+        B = similar(tst_img)
+        grp["area_opening"]["$sz×$sz"] = @benchmarkable area_opening($B, min_area=50)
+    end
+end
+
+SUITE["convexhull"] = BenchmarkGroup()
+let grp = SUITE["convexhull"]
+    grp["convexhull"] = @benchmarkable convexhull($blobs)
+end
+
+SUITE["feature_transform"] = BenchmarkGroup()
+let grp = SUITE["feature_transform"]
+    grp["feature_transform"] = @benchmarkable feature_transform($blobs)
+end

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -1,0 +1,6 @@
+# To run it locally, BenchmarkCI should be added to root project
+using BenchmarkCI
+on_CI = haskey(ENV, "GITHUB_ACTIONS")
+
+BenchmarkCI.judge()
+on_CI ? BenchmarkCI.postjudge() : BenchmarkCI.displayjudgement()


### PR DESCRIPTION
Add a bundle of benchmarks
Choose one function by algorithm class (eg Maxtree approach->area_opening)
Status:
* basic erode/dilate/open could be speedup through specialisation (eg Gray8,binary and 2D cases and simd)
* Maxtree implementation seems good (may we could benchmarks againts flooding approach)
* connected component is quiet good also

On my desk

BenchmarkGroup:
        5-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "feature_transform" => 1-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "feature_transform" => Trial(1.839 ms)
          "convexhull" => 1-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "convexhull" => Trial(385.200 μs)
          "Maxtree" => 1-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "area_opening" => 2-element BenchmarkTools.BenchmarkGroup:
                          tags: []
                          "512×512" => Trial(925.214 ms)
                          "256×256" => Trial(22.914 ms)
          "connected" => 1-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "label_components" => Trial(662.700 μs)
          "dilatation_and_erosion" => 2-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "opening" => 2-element BenchmarkTools.BenchmarkGroup:
                          tags: []
                          "Gray{N0f8}" => 2-element BenchmarkTools.BenchmarkGroup:
                                  tags: []
                                  "512×512" => Trial(1.196 ms)
                                  "256×256" => Trial(286.900 μs)
                          "Gray{Float32}" => 2-element BenchmarkTools.BenchmarkGroup:
                                  tags: []
                                  "512×512" => Trial(4.376 ms)
                                  "256×256" => Trial(732.600 μs)
                  "erode" => 2-element BenchmarkTools.BenchmarkGroup:
                          tags: []
                          "Gray{N0f8}" => 2-element BenchmarkTools.BenchmarkGroup:
                                  tags: []
                                  "512×512" => Trial(580.400 μs)
                                  "256×256" => Trial(144.300 μs)
                          "Gray{Float32}" => 2-element BenchmarkTools.BenchmarkGroup:
                                  tags: []
                                  "512×512" => Trial(2.276 ms)
                                  "256×256" => Trial(365.500 μs)
