### PR TITLE
add connectivity generator helpers

### DIFF
--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -2,6 +2,7 @@ module ImageMorphology
 
 using ImageCore
 using ImageCore: GenericGrayImage
+using ImageCore.OffsetArrays
 using LinearAlgebra
 using TiledIteration: EdgeIterator, SplitAxis, SplitAxes
 using Requires
@@ -17,6 +18,8 @@ include("maxtree.jl")
 
 include("feature_transform.jl")
 using .FeatureTransform
+
+include("utils.jl")
 
 include("deprecations.jl")
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,109 @@
+"""
+    connectivity_ball(radius; square=true)
+    connectivity_ball(radius, Val(N); square=true)
+
+Build the N-dimensional connectivity array by filling the ellipse/ball region with `true`s,
+where `true` indicates a connected position. The default dimension `N` is \$2\$. The
+`square` keyword is used to specify if the output array should be square.
+
+The output shape is specified by `radius`. If `radius` is an `Int` number, then the `true`s
+region forms a ball, and if `radius` is a tuple of `Int`, then it is typically an ellipse.
+
+!!! info "special case: radius == 1"
+    If `radius == 1` then output array will be filled with `true`. For 2-dimensional case,
+    this is also known as C8 connectivity, i.e., `connectivity_region(:C8)`.
+
+```jldoctest; setup = :(using ImageMorphology)
+julia> using ImageMorphology: connectivity_ball
+
+julia> connectivity_ball(1, Val(2))
+3×3 BitMatrix:
+ 1  1  1
+ 1  1  1
+ 1  1  1
+
+julia> connectivity_ball((3, 5), Val(2)) # ellipse
+11×11 BitMatrix:
+ 0  0  0  0  0  0  0  0  0  0  0
+ 0  0  0  0  0  0  0  0  0  0  0
+ 0  0  0  0  0  1  0  0  0  0  0
+ 0  0  1  1  1  1  1  1  1  0  0
+ 0  1  1  1  1  1  1  1  1  1  0
+ 1  1  1  1  1  1  1  1  1  1  1
+ 0  1  1  1  1  1  1  1  1  1  0
+ 0  0  1  1  1  1  1  1  1  0  0
+ 0  0  0  0  0  1  0  0  0  0  0
+ 0  0  0  0  0  0  0  0  0  0  0
+ 0  0  0  0  0  0  0  0  0  0  0
+```
+
+See also [`connectivity_region`](@ref ImageMorphology.connectivity_region).
+"""
+connectivity_ball(radius) = connectivity_ball(radius, Val(2))
+connectivity_ball(r::Int, ::Val{N}) where {N} = connectivity_ball(ntuple(_ -> r, N), Val(N))
+function connectivity_ball(r::NTuple{N,Int}, ::Val{N}; square=true) where {N}
+    sz = square ? ntuple(_ -> 2maximum(r) + 1, N) : @. 2r+1
+
+    # for special case when r==1, it's common to just use `trues(3,3)`
+    all(r .== 1) && return trues(sz)
+
+    # compute the ellips region
+    Ω = falses(sz)
+    c = OffsetArrays.center(Ω)
+    @inbounds for i in CartesianIndices(Ω)
+        v = mapreduce(+, i.I, c, r) do x, x0, a
+            (x - x0)^2 / (a^2)
+        end
+        if v <= 1 # within the ellipse
+            Ω[i] = true
+        end
+    end
+    return Ω
+end
+# this is not type-inferable, yet we still provide it for convenience
+connectivity_ball(radius, n::Int) = connectivity_ball(radius, Val(n))
+
+"""
+    connectivity_region(alias::Symbol)
+    connectivity_region(alias::Symbol, Val(N))
+
+Return commonly used N-dimensional connectivity region by alias.
+
+```jldoctest; setup = :(using ImageMorphology)
+julia> using ImageMorphology: connectivity_region
+
+julia> connectivity_region(:C8) # equivalent to `connectivity_region(8)`
+3×3 BitMatrix:
+ 1  1  1
+ 1  1  1
+ 1  1  1
+```
+
+Currently supported alias are
+
+| dimension | alias     |
+| --------  | --------- |
+| 2         | :C4       |
+| 2         | :C8       |
+
+See also [`connectivity_ball`](@ref ImageMorphology.connectivity_ball).
+"""
+connectivity_region(alias::Symbol) = connectivity_region(alias, Val(2))
+
+# for type-stability, always return BitArray{N}
+function connectivity_region(alias::Symbol, ::Val{2})
+    if alias == :C4
+        Ω = [false true false
+            true true true
+            false true false]
+        return BitMatrix(Ω)
+    elseif alias == :C8
+        return trues(3, 3)
+    else
+        error("unknown connectivity alias for dimension 2: $alias")
+    end
+end
+
+connectivity_region(alias::Symbol, ::Val{N}) where {N} = error("unsupported dimension $N")
+# this is not type-inferable, yet we still provide it for convenience
+connectivity_region(alias, n::Int) = connectivity_region(alias, Val(n))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,11 +3,12 @@
     connectivity_ball(radius, Val(N); square=true)
 
 Build the N-dimensional connectivity array by filling the ellipse/ball region with `true`s,
-where `true` indicates a connected position. The default dimension `N` is \$2\$. The
-`square` keyword is used to specify if the output array should be square.
+where `true` indicates a connected position to its center. The default dimension `N` is
+\$2\$.
 
 The output shape is specified by `radius`. If `radius` is an `Int` number, then the `true`s
 region forms a ball, and if `radius` is a tuple of `Int`, then it is typically an ellipse.
+The `square` keyword is used to specify if the output array should be square.
 
 !!! info "special case: radius == 1"
     If `radius == 1` then output array will be filled with `true`. For 2-dimensional case,
@@ -22,27 +23,31 @@ julia> connectivity_ball(1, Val(2))
  1  1  1
  1  1  1
 
-julia> connectivity_ball((3, 5), Val(2)) # ellipse
-11×11 BitMatrix:
- 0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  1  0  0  0  0  0
- 0  0  1  1  1  1  1  1  1  0  0
- 0  1  1  1  1  1  1  1  1  1  0
- 1  1  1  1  1  1  1  1  1  1  1
- 0  1  1  1  1  1  1  1  1  1  0
- 0  0  1  1  1  1  1  1  1  0  0
- 0  0  0  0  0  1  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0
+julia> connectivity_ball((1, 3)) # ellipse
+7×7 BitMatrix:
+ 0  0  0  0  0  0  0
+ 0  0  0  0  0  0  0
+ 0  0  0  1  0  0  0
+ 1  1  1  1  1  1  1
+ 0  0  0  1  0  0  0
+ 0  0  0  0  0  0  0
+ 0  0  0  0  0  0  0
+
+julia> connectivity_ball((1, 3); square=false) # ellipse
+3×7 BitMatrix:
+ 0  0  0  1  0  0  0
+ 1  1  1  1  1  1  1
+ 0  0  0  1  0  0  0
 ```
 
 See also [`connectivity_region`](@ref ImageMorphology.connectivity_region).
 """
-connectivity_ball(radius) = connectivity_ball(radius, Val(2))
-connectivity_ball(r::Int, ::Val{N}) where {N} = connectivity_ball(ntuple(_ -> r, N), Val(N))
+connectivity_ball(radius; kwargs...) = connectivity_ball(radius, Val(2); kwargs...)
+function connectivity_ball(r::Int, ::Val{N}; kwargs...) where {N}
+    return connectivity_ball(ntuple(_ -> r, N), Val(N); kwargs...)
+end
 function connectivity_ball(r::NTuple{N,Int}, ::Val{N}; square=true) where {N}
-    sz = square ? ntuple(_ -> 2maximum(r) + 1, N) : @. 2r+1
+    sz = square ? ntuple(_ -> 2maximum(r) + 1, N) : @. 2r + 1
 
     # for special case when r==1, it's common to just use `trues(3,3)`
     all(r .== 1) && return trues(sz)
@@ -61,7 +66,7 @@ function connectivity_ball(r::NTuple{N,Int}, ::Val{N}; square=true) where {N}
     return Ω
 end
 # this is not type-inferable, yet we still provide it for convenience
-connectivity_ball(radius, n::Int) = connectivity_ball(radius, Val(n))
+connectivity_ball(radius, n::Int; kwargs...) = connectivity_ball(radius, Val(n); kwargs...)
 
 """
     connectivity_region(alias::Symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ Base.VERSION >= v"1.6" && doctest(ImageMorphology, manual = false)
     include("maxtree.jl")
     include("feature_transform.jl")
     include("clearborder.jl")
+    include("utils.jl")
     @info "Beginning deprecation tests, warnings are expected"
     include("deprecations.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,6 +27,8 @@
     ref = Bool[0 0 0 1 0 0 0; 1 1 1 1 1 1 1; 0 0 0 1 0 0 0]
     @test typeof(out) == BitMatrix
     @test out == ref
+    # ensure keywords are passed through
+    @test ref == _build((1, 3); square=false) == _build((1, 3), 2; square=false)
 
     # N=3
     out = @inferred _build(2, Val(3))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,73 @@
+@testset "connectivity_ball" begin
+    _build = ImageMorphology.connectivity_ball
+
+    # N=1
+    out = @inferred _build(1, Val(1))
+    @test typeof(out) == BitVector
+    @test out == [true, true, true]
+
+    # N=2 (default case)
+    out = @inferred _build(1, Val(2))
+    @test typeof(out) == BitMatrix
+    @test out == trues(3, 3)
+    @test out == _build(1)
+
+    out = @inferred _build((1, 3), Val(2)) # ellipse
+    ref = Bool[0 0 0 0 0 0 0
+        0 0 0 0 0 0 0
+        0 0 0 1 0 0 0
+        1 1 1 1 1 1 1
+        0 0 0 1 0 0 0
+        0 0 0 0 0 0 0
+        0 0 0 0 0 0 0]
+    @test typeof(out) == BitMatrix
+    @test out == ref
+
+    out = @inferred _build((1, 3), Val(2); square=false) # ellipse
+    ref = Bool[0 0 0 1 0 0 0; 1 1 1 1 1 1 1; 0 0 0 1 0 0 0]
+    @test typeof(out) == BitMatrix
+    @test out == ref
+
+    # N=3
+    out = @inferred _build(2, Val(3))
+    ref = cat(
+        Bool[0 0 0 0 0; 0 0 0 0 0; 0 0 1 0 0; 0 0 0 0 0; 0 0 0 0 0],
+        Bool[0 0 0 0 0; 0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0; 0 0 0 0 0],
+        Bool[0 0 1 0 0; 0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0; 0 0 1 0 0],
+        Bool[0 0 0 0 0; 0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0; 0 0 0 0 0],
+        Bool[0 0 0 0 0; 0 0 0 0 0; 0 0 1 0 0; 0 0 0 0 0; 0 0 0 0 0];
+        dims=3
+    )
+    @test typeof(out) == BitArray{3}
+    @test out == ref
+
+    # not type-inferable
+    err = ErrorException("return type BitMatrix does not match inferred return type Any")
+    @test_throws err @inferred _build(1, 2)
+    @test _build(1, 2) == _build(1, Val(2))
+
+    # exceptions
+    @test_throws MethodError _build((1,), Val(2))
+    @test_throws MethodError _build((1, 2, 3), Val(2))
+end
+
+@testset "connectivity_region" begin
+    _build = ImageMorphology.connectivity_region
+
+    # N=2, C4
+    out = @inferred _build(:C4)
+    ref = Bool[false true false; true true true; false true false]
+    @test typeof(out) == BitMatrix
+    @test out == ref
+    @test out == _build(:C4, Val(2))
+
+    # N=2, C8
+    out = _build(:C8)
+    ref = trues(3, 3)
+    @test typeof(out) == BitMatrix
+    @test out == ref
+
+    # exceptions
+    err = ErrorException("unknown connectivity alias for dimension 2: null")
+    @test_throws err _build(:null)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -31,7 +31,11 @@
     @test ref == _build((1, 3); square=false) == _build((1, 3), 2; square=false)
 
     # N=3
-    out = @inferred _build(2, Val(3))
+    out = if VERSION >= v"1.6"
+        @inferred _build(2, Val(3))
+    else
+        _build(2, Val(3))
+    end
     ref = cat(
         Bool[0 0 0 0 0; 0 0 0 0 0; 0 0 1 0 0; 0 0 0 0 0; 0 0 0 0 0],
         Bool[0 0 0 0 0; 0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0; 0 0 0 0 0],
@@ -44,7 +48,7 @@
     @test out == ref
 
     # not type-inferable
-    err = ErrorException("return type BitMatrix does not match inferred return type Any")
+    err = ErrorException("return type $(BitMatrix) does not match inferred return type Any")
     @test_throws err @inferred _build(1, 2)
     @test _build(1, 2) == _build(1, Val(2))
 
@@ -69,7 +73,12 @@ end
     @test typeof(out) == BitMatrix
     @test out == ref
 
+    # not guaranteed to be type-inferable
+    @test _build(:C4, 2) == _build(:C4, Val(2))
+
     # exceptions
     err = ErrorException("unknown connectivity alias for dimension 2: null")
     @test_throws err _build(:null)
+    err = ErrorException("unsupported dimension 999")
+    @test_throws err _build(:null, Val(999))
 end


### PR DESCRIPTION
This commit introduces two helper functions to build connectivity
array

- `connectivity_ball(radius, Val(N))`
- `connectivity_region(alias, Val(N))`

@ThomasRetornaz I separate this commit from #60, since you're the expert can you help review this? I personally rarely use morphology.