### PR TITLE
foundamental support for structuring element concept

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.3', '1.6', '1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Documenter = "0.24, 0.25"
 ImageCore = "0.9"
 Requires = "1"
 TiledIteration = "0.3.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ julia = "1.3"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "ImageMetadata", "OffsetArrays", "Test"]
+test = ["Documenter", "ImageMetadata", "OffsetArrays", "Suppressor", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ImageMorphology
 
+![Julia version](https://img.shields.io/badge/julia-%3E%3D%201.6-blue)
 [![][action-img]][action-url]
 [![][pkgeval-img]][pkgeval-url]
 [![][codecov-img]][codecov-url]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageMorphology = "787d08f9-d448-5407-9aad-5290dd7ab264"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,18 @@
 using Documenter
 using ImageMorphology
-using ImageCore, ImageShow, TestImages
+using ImageBase, ImageShow, TestImages
 
 prettyurls = get(ENV, "CI", nothing) == "true"
 format = Documenter.HTML(; prettyurls)
 
-pages = ["index.md", "reference.md"]
-makedocs(; modules=[ImageMorphology], format=format, sitename="ImageMorphology", pages=[])
+#! format: off
+pages = Any[
+    "index.md",
+    "Concepts" => Any["structuring_element.md"],
+    "reference.md"
+]
+#! format: on
+
+makedocs(; modules=[ImageMorphology], format=format, sitename="ImageMorphology", pages)
 
 deploydocs(; repo="github.com/JuliaImages/ImageMorphology.jl.git")

--- a/docs/src/structuring_element.md
+++ b/docs/src/structuring_element.md
@@ -133,13 +133,13 @@ single line:
 Among all the SE possibilities, this package provides constructors for two commonly used cases:
 
 - diamond-like constructor: [`strel_diamond`](@ref)
-- window-like constructor: [`strel_window`](@ref)
+- box-like constructor: [`strel_box`](@ref)
 
 ```@repl concept_se
 strel_diamond((3, 3)) # immediate neighborhood: C4 connectivity
 strel_diamond((3, 3), (1, )) # along the first dimension
-strel_window((3, 3)) # all adjacent neighborhood: C8 connectivity
-strel_window((3, 3), (1, ))
+strel_box((3, 3)) # all adjacent neighborhood: C8 connectivity
+strel_box((3, 3), (1, ))
 ```
 
 Utilizing these constructors, we can provide an easier-to-use `my_erode(A, [dims])` interface by
@@ -150,7 +150,7 @@ my_erode(A, dims::Dims=ntuple(identity, ndims(A))) = my_erode(A, strel_diamond(A
 ```
 
 !!! tip "Performance tip: keep the array type"
-    For the structuring element `Ω` generated from `strel_diamond` and `strel_window`, it is likely
+    For the structuring element `Ω` generated from `strel_diamond` and `strel_box`, it is likely
     to hit a fast path if you keep its array type. For instance, `erode(A, strel_diamond(A))` is
     usually faster than `erode(A, Array(strel_diamond(A)))` because more information of the `Ω`
     shape is passed to Julia during coding and compilation.
@@ -195,4 +195,4 @@ simple lookup table that reflects our previous reasoning:
 | displacement offset     | `CartesianIndex` | `SEOffset`   |
 | connectivity mask       | `Bool`           | `SEMask`     |
 | [`strel_diamond`](@ref) | `Bool`           | `SEDiamond`  |
-| [`strel_window`](@ref)  | `Bool`           | `SEWindow`   |
+| [`strel_box`](@ref)     | `Bool`           | `SEBox`      |

--- a/docs/src/structuring_element.md
+++ b/docs/src/structuring_element.md
@@ -1,0 +1,198 @@
+```@setup concept_se
+using ImageMorphology
+using ImageBase
+using TestImages
+```
+
+# Structuring element
+
+Structuring Element (SE) is the key concept in morphology to indicate the connectivity and the
+neighborhood. This page explains this structuring element concept, and how ImageMorphology supports
+the general SEs without compromising the performance on the most commonly used special SE cases.
+
+## The erosion example
+
+The erosion `erode` function in its simplest 1-dimensional case can be defined as
+
+$$\varepsilon_A[p] = min(A[p-1], A[p], A[p+1])$$
+
+Because the output value at position $p$ not only depends on its own pixel `A[p]` but also on
+its neighborhood values `A[p-1]` and `A[p+1]`, we call this type of operation a _neighborhood
+image transformation_.
+
+Now comes the question: **if we try to generalize the `erode` function, what should we do?** --
+we would like to generalize the concept of "neighborhood".
+
+## Two neighborhood representations
+
+By saying "$\Omega_p$ is the neighborhood of $p$", we are expressing `p in Ωₚ` in plain Julia. For
+performance consideration, this `Ωₚ` is usually generated from the `(p, Ω)` pair. `p` is the center
+point that changes during the iteration, and `Ω` is usually a pre-defined and unchanged data which
+contains the neighborhood and shape information. We call this `Ω` a _structuring element_. There are
+usually two ways to express `Ω`:
+
+- **displacement offset**: a list of `CartesianIndex` to inidcate the offset to the center point `p`
+- **connectivity mask**: a bool array mask to indicate the connectivity to the center point `p`
+
+For instance, in the following code block we build a commonly named C4 connectivity in the 2-dimensional case:
+
+```@example concept_se
+# displacement offset
+Ω_offsets = [
+    CartesianIndex(-1, 0),
+    CartesianIndex(0, -1),
+    CartesianIndex(0, 1),
+    CartesianIndex(1, 0),
+]
+
+# connectivity mask
+Ω_bool = Bool[
+    0 1 0
+    1 1 1
+    0 1 0
+]
+nothing #hide
+```
+
+If `p=CartesianIndex(3, 3)`, then we know `p=CartesianIndex(3, 4)` is in `Ωₚ`.
+
+Now, back to the erosion example. Based on the displacement offset representation, the simplest
+generic version of `erode` can be implemented quite simply:
+
+```@example concept_se
+# For illustration only, performance can be greatly improved using iteration to eliminate allocations
+function my_erode(A, Ω)
+    out = similar(A)
+    R = CartesianIndices(A)
+    for p in R
+        Ωₚ = filter!(q->in(q, R), Ref(p) .+ Ω)
+        # here we don't assume p in Ωₚ
+        out[p] = min(A[p], minimum(A[Ωₚ]))
+    end
+    return out
+end
+nothing #hide
+```
+
+```@example concept_se
+using ImageMorphology
+using ImageBase
+using TestImages
+
+img = Gray.(testimage("morphology_test_512"))
+img = Gray.(img .< 0.8)
+img_e = my_erode(img, Ω_offsets)
+mosaic(img, img_e; nrow=1)
+```
+
+As you may realize, the displacement offset representation is convenient to use when implementing
+algorithms, but it is hard to visualize. In contrast, the connectivity mask is not so convenient to
+use when implementing algorithms, but it is easy to visualize. For instance, one can very easily
+understand the following SE at the first glance:
+
+```@example concept_se
+Ω = Bool[1 1 1; 1 1 0; 0 0 0] # hide
+```
+
+but not
+
+```@example concept_se
+strel(CartesianIndex, Ω) # hide
+```
+
+## The `strel` function
+
+This package supports the conversion between different SE representations via the [`strel`](@ref)
+helper function. `strel` is the short name for "STRucturing ELement".
+
+To convert a connectivity mask representation to displacement offset representation:
+
+```@example concept_se
+Ω_mask = Bool[1 1 1; 1 1 0; 0 0 0]
+Ω_offsets = strel(CartesianIndex, Ω_mask)
+```
+
+And to convert back from a displacement offset representation to connectivity mask representation:
+
+```@example concept_se
+strel(Bool, Ω_offsets)
+```
+
+Quite simple, right? Thus to make our `my_erode` function more generic, we only need to add one
+single line:
+
+```diff
+ function my_erode(A, Ω)
+     out = similar(A)
++    Ω = strel(CartesianIndex, Ω)
+     R = CartesianIndices(A)
+```
+
+## Convenient constructors
+
+Among all the SE possibilities, this package provides constructors for two commonly used cases:
+
+- diamond-like constructor: [`strel_diamond`](@ref)
+- window-like constructor: [`strel_window`](@ref)
+
+```@repl concept_se
+strel_diamond((3, 3)) # immediate neighborhood: C4 connectivity
+strel_diamond((3, 3), (1, )) # along the first dimension
+strel_window((3, 3)) # all adjacent neighborhood: C8 connectivity
+strel_window((3, 3), (1, ))
+```
+
+Utilizing these constructors, we can provide an easier-to-use `my_erode(A, [dims])` interface by
+adding one more method:
+
+```julia
+my_erode(A, dims::Dims=ntuple(identity, ndims(A))) = my_erode(A, strel_diamond(A, dims))
+```
+
+!!! tip "Performance tip: keep the array type"
+    For the structuring element `Ω` generated from `strel_diamond` and `strel_window`, it is likely
+    to hit a fast path if you keep its array type. For instance, `erode(A, strel_diamond(A))` is
+    usually faster than `erode(A, Array(strel_diamond(A)))` because more information of the `Ω`
+    shape is passed to Julia during coding and compilation.
+
+## Performance optimizations and the `strel_type` function
+
+Thanks to Julia's multiple dispatch mechanism, we can provide all the optimization tricks without
+compromising the simple user interface. This can be programmatically done with the help of the
+`strel_type` function. For example, if you know a very efficient `erode` implementation for the C4
+connectivity SE, then you can add it incrementally:
+
+```julia
+using ImageMorphology: MorphologySE, SEDiamond
+
+my_erode(A, dims::Dims) = my_erode(A, strel_diamond(A, dims))
+my_erode(A, Ω) = _my_erode(strel_type(Ω), A, Ω)
+
+# the generic implementation we've written above
+function _my_erode(::MorphologySE, A, Ω)
+   ...
+end
+
+# the optimized implementation for SE generated from `strel_diamond` function
+function _my_erode(::SEDiamond, A, Ω)
+   ...
+end
+
+# ... and other optimized versions, if there are
+```
+
+In essence, `strel_type` is a trait function to assist the dispatch and code design:
+
+```@repl concept_se
+strel_type(Ω_mask)
+```
+
+It returns an internal object `SEMask{2}()`. This might look scary at first glance, but it's quite a
+simple lookup table that reflects our previous reasoning:
+
+| representation          | element type     | `strel_type` |
+| ----------------------- | ---------------- | ------------ |
+| displacement offset     | `CartesianIndex` | `SEOffset`   |
+| connectivity mask       | `Bool`           | `SEMask`     |
+| [`strel_diamond`](@ref) | `Bool`           | `SEDiamond`  |
+| [`strel_window`](@ref)  | `Bool`           | `SEWindow`   |

--- a/docs/src/structuring_element.md
+++ b/docs/src/structuring_element.md
@@ -4,7 +4,7 @@ using ImageBase
 using TestImages
 ```
 
-# Structuring element
+# [Structuring element](@id concept_se)
 
 Structuring Element (SE) is the key concept in morphology to indicate the connectivity and the
 neighborhood. This page explains this structuring element concept, and how ImageMorphology supports

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -25,6 +25,7 @@ include("deprecations.jl")
 export
     strel,
     strel_type,
+    strel_size,
     strel_diamond,
     strel_window,
 

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -27,7 +27,7 @@ export
     strel_type,
     strel_size,
     strel_diamond,
-    strel_window,
+    strel_box,
 
     dilate,
     dilate!,

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -2,10 +2,12 @@ module ImageMorphology
 
 using ImageCore
 using ImageCore: GenericGrayImage
+using ImageCore.OffsetArrays
 using LinearAlgebra
 using TiledIteration: EdgeIterator, SplitAxis, SplitAxes
 using Requires
 
+include("structuring_element.jl")
 include("convexhull.jl")
 include("connected.jl")
 include("clearborder.jl")
@@ -21,6 +23,11 @@ using .FeatureTransform
 include("deprecations.jl")
 
 export
+    strel,
+    strel_type,
+    strel_diamond,
+    strel_window,
+
     dilate,
     dilate!,
     erode,

--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -1,0 +1,303 @@
+abstract type MorphologySE{N} end
+
+"""
+    SEMask{N}()
+
+The N-dimensional structuring element in terms of bool array as mask. Typically, `true`
+represents the foreground and `false` represents the background.
+"""
+struct SEMask{N} <: MorphologySE{N} end
+
+"""
+    SEOffset{N}()
+
+The N-dimensional structuring element in terms of displacement offset.
+"""
+struct SEOffset{N} <: MorphologySE{N} end
+
+"""
+    SEDiamond{N}([size], [dims]; r=1)
+
+The N-dimensional diamond shape structuring element.
+"""
+struct SEDiamond{N,K} <: MorphologySE{N}
+    size::Dims{N}
+    dims::Dims{K}
+    r::Int # radius
+    function SEDiamond{N,K}(size::Dims{N}, dims::Dims{K}, r) where {N,K}
+        all(isodd, size) || throw(ArgumentError("all size should be odd number"))
+        _is_unique_tuple(dims) || throw(ArgumentError("dims should be unique"))
+        N >= K || throw(ArgumentError("`size` length should be at least $K"))
+        all(i->i<=N, dims) || throw(ArgumentError("all `dims` values should be less than or equal to $N"))
+        return new{N,K}(size, dims, r)
+    end
+end
+function SEDiamond{N}(sz=ntuple(_ -> 3, N), dims=ntuple(identity, N); r=1) where {N}
+    return SEDiamond{N,length(dims)}(sz, dims, r)
+end
+
+"""
+    SEWindow{N}([size], [dims]; r=1)
+
+The N-dimensional structuring element with all elements connected.
+"""
+struct SEWindow{N,K} <: MorphologySE{N}
+    size::Dims{N}
+    dims::Dims{K}
+    r::Int # radius
+    function SEWindow{N,K}(size::Dims{N}, dims::Dims{K}, r) where {N,K}
+        all(isodd, size) || throw(ArgumentError("all size should be odd number"))
+        _is_unique_tuple(dims) || throw(ArgumentError("dims should be unique"))
+        N >= K || throw(ArgumentError("`size` length should be at least $K"))
+        all(i->i<=N, dims) || throw(ArgumentError("all `dims` values should be less than or equal to $N"))
+        return new{N,K}(size, dims, r)
+    end
+end
+function SEWindow{N}(sz=ntuple(_ -> 3, N), dims=ntuple(identity, N); r=1) where {N}
+    return SEWindow{N,length(dims)}(sz, dims, r)
+end
+
+# Helper array type to build a consistant array interface for SEs
+struct SEDiamondArray{N,K,S} <: AbstractArray{Bool,N}
+    size::Dims{N}
+    dims::Dims{K}
+    r::Int # radius
+    _center::Dims{N}
+    _rdims::Dims{S}
+end
+function SEDiamondArray(se::SEDiamond{N,K}) where {N,K}
+    _center = @. (se.size + 1) ÷ 2
+    _rdims = _cal_rdims(Val(N), se.dims)
+    return SEDiamondArray{N,K,length(_rdims)}(se.size, se.dims, se.r, _center, _rdims)
+end
+
+@inline Base.size(A::SEDiamondArray{N}) where {N} = A.size
+@inline Base.IndexStyle(::SEDiamondArray) = IndexCartesian()
+Base.@propagate_inbounds function Base.getindex(A::SEDiamondArray{N,K}, inds::Int...) where {N,K}
+    # for remaining dimensions, check if it is at the center position
+    ri = _tuple_getindex(inds, A._rdims)
+    rc = _tuple_getindex(A._center, A._rdims)
+    ri == rc || return false
+    # for masked dimensions, compare if the city-block distance to center is within radius
+    mi = _tuple_getindex(inds, A.dims)
+    mc = _tuple_getindex(A._center, A.dims)
+    r = A.r
+    return ifelse(sum(abs, mi .- mc) > r, false, true)
+end
+
+struct SEWindowArray{N,K,S} <: AbstractArray{Bool,N}
+    dims::Dims{K}
+    size::Dims{N}
+    r::Int
+    _center::Dims{N}
+    _rdims::Dims{S}
+end
+function SEWindowArray(se::SEWindow{N,K}) where {N,K}
+    _center = @. (se.size + 1) ÷ 2
+    _rdims = _cal_rdims(Val(N), se.dims)
+    return SEWindowArray{N,K,length(_rdims)}(se.dims, se.size, se.r, _center, _rdims)
+end
+
+@inline Base.size(A::SEWindowArray) = A.size
+@inline function Base.getindex(A::SEWindowArray, inds::Int...)
+    # for remaining dimensions, check if it is at the center position
+    ri = _tuple_getindex(inds, A._rdims)
+    rc = _tuple_getindex(A._center, A._rdims)
+    ri == rc || return false
+
+    # for masked dimensions, compare if any of the index is within radius
+    mi = _tuple_getindex(inds, A.dims)
+    mc = _tuple_getindex(A._center, A.dims)
+    return ifelse(any(abs.(mi .- mc) .> A.r), false, true)
+end
+
+_tuple_getindex(t::Tuple, inds::Dims) = ntuple(i->t[inds[i]], length(inds))
+_cal_rdims(::Val{N}, dims::NTuple{K}) where {N,K} = Dims{N-K}(filter(i->!in(i, dims), 1:N))
+_is_unique_tuple(t::Tuple) = any(i->t[i] in t[1:i-1], 2:length(t)) ? false : true
+
+
+"""
+    strel_type(x)
+
+Infer the structuring element type for `x`.
+"""
+strel_type(se::MorphologySE) = se
+strel_type(::AbstractArray{Bool,N}) where {N} = SEMask{N}()
+strel_type(::AbstractVector{CartesianIndex{N}}) where {N} = SEOffset{N}()
+strel_type(::CartesianIndices{N}) where {N} = SEOffset{N}()
+strel_type(A::SEDiamondArray{N}) where {N} = SEDiamond{N}(size(A), A.dims; r=A.r)
+strel_type(A::SEWindowArray{N}) where {N} = SEWindow{N}(size(A), A.dims)
+strel_type(::T) where T = error("invalid structuring element data type: $T")
+
+"""
+    strel_ndims(x)::Int
+
+Infer the dimension of the structuring element `x`
+"""
+strel_ndims(se) = strel_ndims(strel_type(se))
+strel_ndims(::MorphologySE{N}) where {N} = N
+
+"""
+    strel([T], X::AbstractArray)
+
+Convert structuring element (SE) `X` to appropriate presentation format with element type `T`.
+This is a useful tool to generate SE that most ImageMorphology functions understand.
+
+ImageMorphology currently supports two commonly used representations:
+
+- `T=CartesianIndex`: offsets to its center point. The output type is
+  `Vector{CartesianIndex{N}}`.
+- `T=Bool`: connectivity mask where `true` indicates connected to its center point. The
+  output type is `BitArray{N}`.
+
+```jldoctest; setup=:(using ImageMorphology)
+julia> se_mask = Bool[1 1 0; 1 1 0; 0 0 0] # connectivity mask
+3×3 Matrix{Bool}:
+ 1  1  0
+ 1  1  0
+ 0  0  0
+
+julia> se_offsets = strel(CartesianIndex, se_mask) # displacement offsets to its center point
+3-element Vector{CartesianIndex{2}}:
+ CartesianIndex(-1, -1)
+ CartesianIndex(0, -1)
+ CartesianIndex(-1, 0)
+
+julia> se = strel(Bool, se_offsets)
+3×3 BitMatrix:
+ 1  1  0
+ 1  1  0
+ 0  0  0
+```
+
+See also [`strel_diamond`](@ref) and [`strel_window`](@ref) for SE constructors for two
+special cases.
+"""
+function strel end
+
+strel(se) = strel(strel_type(se), se)
+
+# convenient user interface without exporting MorphologySE
+strel(::Type{ET}, se::AbstractArray) where {ET<:CartesianIndex} = strel(SEOffset{strel_ndims(se)}(), se)
+strel(::Type{ET}, se::AbstractArray) where {ET<:Bool} = strel(SEMask{strel_ndims(se)}(), se)
+
+# constructor for special SEs
+_strel_array(se::SEDiamond) = SEDiamondArray(se)
+_strel_array(se::SEWindow) = SEWindowArray(se)
+
+"""
+    strel_diamond(img, [dims]; r=1)
+    strel_diamond(size, [dims]; r=1)
+
+Construct the N-dimensional structuring element (SE) for a diamond shape. If image is
+provided, then `size=(3, 3, ...)` and `(1, 2, ..., N)` are the default values for `size` and
+`dims`.
+
+```jldoctest; setup=:(using ImageMorphology)
+julia> img = rand(64, 64);
+
+julia> se = strel_diamond(img)
+3×3 ImageMorphology.SEDiamondArray{2, 2, 0}:
+ 0  1  0
+ 1  1  1
+ 0  1  0
+
+julia> se = strel_diamond((3,3), (1,)) # 3×3 mask along dimension 1
+3×3 ImageMorphology.SEDiamondArray{2, 1, 1}:
+ 0  1  0
+ 0  1  0
+ 0  1  0
+
+julia> se = strel_diamond((3,5); r=2) # 3×5 mask with radius 2
+3×5 ImageMorphology.SEDiamondArray{2, 2, 0}:
+ 0  1  1  1  0
+ 1  1  1  1  1
+ 0  1  1  1  0
+```
+
+!!! note "specialization and performance"
+    The diamond shape `SEDiamond` is a special type that many morpholoy algorithms may
+    provide much more efficient implementations for. For this reason, if one tries to
+    collect an `SEDiamondArray` into other array types (e.g., `Array{Bool}` via `collect`),
+    then a significant performance drop might be very likely to happen.
+
+See also [`strel`](@ref) and [`strel_window`](@ref).
+"""
+function strel_diamond(img::AbstractArray{T,N}, dims=coords_spatial(img); kw...) where {T,N}
+    return strel_diamond(ntuple(i->3, N), dims; kw...)
+end
+function strel_diamond(sz::Dims{N}, dims::Dims{K}=ntuple(identity, N); kw...) where {N,K}
+    return _strel_array(SEDiamond{N}(sz, dims; kw...))
+end
+
+"""
+    strel_window(img, [dims]; r=1)
+    strel_window(size, [dims]; r=1)
+
+Construct the N-dimensional structuring element (SE) with all elements in the local window
+connected. If image is provided, then `size=(3, 3, ...)` and `(1, 2, ..., N)` are the
+default values for `size` and `dims`.
+
+```jldoctest; setup=:(using ImageMorphology)
+julia> img = rand(64, 64);
+
+julia> se = strel_window(img)
+3×3 ImageMorphology.SEWindowArray{2, 2, 0}:
+ 1  1  1
+ 1  1  1
+ 1  1  1
+
+julia> se = strel_window((3,3), (1,)) # 3×3 mask along dimension 1
+3×3 ImageMorphology.SEWindowArray{2, 1, 1}:
+ 0  1  0
+ 0  1  0
+ 0  1  0
+
+julia> se = strel_window((3,5); r=2) # 3×5 mask with radius 2
+3×5 ImageMorphology.SEWindowArray{2, 2, 0}:
+ 1  1  1  1  1
+ 1  1  1  1  1
+ 1  1  1  1  1
+```
+
+!!! note "specialization and performance"
+    The window shape `SEWindow` is a special type that many morpholoy algorithms may
+    provide efficient implementations for. For this reason, if one tries to collect an
+    `SEWindowArray` into other array types (e.g., `Array{Bool}` via `collect`), then a
+    significant performance drop might be very likely to happen.
+
+See also [`strel`](@ref) and [`strel_window`](@ref).
+"""
+function strel_window(img::AbstractArray{T,N}, dims=coords_spatial(img); kw...) where {T,N}
+    return strel_window(ntuple(i->3, N), dims; kw...)
+end
+function strel_window(sz::Dims{N}, dims::Dims{K}=ntuple(identity, N); kw...) where {N,K}
+    return _strel_array(SEWindow{N}(sz, dims; kw...))
+end
+
+# conversion between different SE arrays
+function strel(SET::MorphologySE, se::T) where {T}
+    strel_type(se) == SET || error("unsupported conversion from type $T to $SET")
+    return se
+end
+
+function strel(::SEMask{N}, offsets::AbstractArray{CartesianIndex{N}}) where {N}
+    isempty(offsets) && return trues(ntuple(_->1, N))
+    mn, mx = extrema(offsets)
+    r = ntuple(N) do i
+        max(abs(mn.I[i]), abs(mx.I[i]))
+    end
+    sz = @. 2r + 1
+    se = OffsetArrays.centered(falses(sz))
+    se[offsets] .= true
+    se[zero(eltype(offsets))] = true # always set center point to true
+    return BitArray(OffsetArrays.no_offset_view(se))
+end
+strel(::SEMask{N}, mask::AbstractArray{Bool,N}) where {N} = mask
+
+function strel(::SEOffset{N}, connectivity::AbstractArray{Bool,N}) where {N}
+    all(isodd, size(connectivity)) || error("`connectivity` must be odd-sized")
+    connectivity = OffsetArrays.centered(connectivity)
+    # always skip center point
+    return [i for i in CartesianIndices(connectivity) if connectivity[i] && !iszero(i)]
+end

--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -269,10 +269,10 @@ julia> se = strel_diamond((3,5); r=2) # 3×5 mask with radius 2
 ```
 
 !!! note "specialization and performance"
-    The diamond shape `SEDiamond` is a special type that many morpholoy algorithms may
-    provide much more efficient implementations for. For this reason, if one tries to
-    collect an `SEDiamondArray` into other array types (e.g., `Array{Bool}` via `collect`),
-    then a significant performance drop might be very likely to happen.
+    The diamond shape `SEDiamond` is a special type for which many morphology algorithms may
+    provide much more efficient implementations. For this reason, if one tries to
+    collect an `SEDiamondArray` into other array types (e.g. `Array{Bool}` via `collect`),
+    then a significant performance drop is very likely to occur.
 
 See also [`strel`](@ref) and [`strel_window`](@ref).
 """
@@ -314,10 +314,10 @@ julia> se = strel_window((3,5); r=2) # 3×5 mask with radius 2
 ```
 
 !!! note "specialization and performance"
-    The window shape `SEWindow` is a special type that many morpholoy algorithms may
-    provide efficient implementations for. For this reason, if one tries to collect an
-    `SEWindowArray` into other array types (e.g., `Array{Bool}` via `collect`), then a
-    significant performance drop might be very likely to happen.
+    The window shape `SEWindow` is a special type for which many morphology algorithms may
+    provide efficient implementations. For this reason, if one tries to collect an
+    `SEWindowArray` into other array types (e.g. `Array{Bool}` via `collect`), then a
+    significant performance drop is very likely to occur.
 
 See also [`strel`](@ref) and [`strel_window`](@ref).
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using ImageCore
 using Test
 using OffsetArrays
 using ImageMetadata
+using Suppressor
 
 @test isempty(detect_ambiguities(ImageMorphology))
 
@@ -10,6 +11,7 @@ using Documenter
 Base.VERSION >= v"1.6" && doctest(ImageMorphology, manual = false)
 
 @testset "ImageMorphology" begin
+    include("structuring_element.jl")
     include("convexhull.jl")
     include("connected.jl")
     include("dilation_and_erosion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ImageMorphology
 using ImageCore
 using Test
 using OffsetArrays
+using OffsetArrays: centered
 using ImageMetadata
 using Suppressor
 

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -33,42 +33,22 @@
 
     @testset "mask to offset" begin
         se = centered(Bool[1, 0, 1])
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, se)
-        else
-            strel(CartesianIndex, se)
-        end
+        se_offsets = @inferred strel(CartesianIndex, se)
         @test se_offsets == [CartesianIndex(-1,), CartesianIndex(1,)]
         @test se_offsets == strel(CartesianIndex, centered(Bool[1, 1, 1]))
 
         se = centered(Bool[1 0 0; 0 1 0; 0 0 1])
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, se)
-        else
-            strel(CartesianIndex, se)
-        end
+        se_offsets = @inferred strel(CartesianIndex, se)
         @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
         # internally, CartesianIndex is converted to SEOffset
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(ImageMorphology.SEOffset{2}(), se)
-        else
-            strel(ImageMorphology.SEOffset{2}(), se)
-        end
+        se_offsets = @inferred strel(ImageMorphology.SEOffset{2}(), se)
         @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
 
         se = centered(trues((3, 3)))
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, se)
-        else
-            strel(CartesianIndex, se)
-        end
+        se_offsets = @inferred strel(CartesianIndex, se)
         @test se_offsets == filter(x -> !iszero(x), vec(CartesianIndices((-1:1, -1:1))))
 
-        se = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, centered(falses(3, 3)))
-        else
-            strel(CartesianIndex, centered(falses(3, 3)))
-        end
+        se = @inferred strel(CartesianIndex, centered(falses(3, 3)))
         @test isempty(se)
 
         # test deprecation
@@ -83,11 +63,7 @@
     @testset "center point" begin
         for se in centered.([Bool[1 0 0; 0 1 0; 0 0 1], Bool[1 0 0; 0 0 0; 0 0 1]])
             # center point is always excluded in offsets
-            se_offsets = if VERSION >= v"1.6"
-                @inferred strel(CartesianIndex, se)
-            else
-                strel(CartesianIndex, se)
-            end
+            se_offsets = @inferred strel(CartesianIndex, se)
             @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
             # but included in mask
             se_mask = @inferred strel(Bool, se_offsets)
@@ -157,11 +133,7 @@ end
 
     @testset "strel conversion" begin
         se = strel_diamond((3, 3))
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, se)
-        else
-            strel(CartesianIndex, se)
-        end
+        se_offsets = @inferred strel(CartesianIndex, se)
         @test se_offsets == [CartesianIndex(0, -1), CartesianIndex(-1, 0), CartesianIndex(1, 0), CartesianIndex(0, 1)]
         se_mask = @inferred strel(Bool, se)
         # not BitMatrix as SEDiamondArray provides more information of what the SE is
@@ -238,11 +210,7 @@ end
 
     @testset "strel conversion" begin
         se = strel_box((3, 3))
-        se_offsets = if VERSION >= v"1.6"
-            @inferred strel(CartesianIndex, se)
-        else
-            strel(CartesianIndex, se)
-        end
+        se_offsets = @inferred strel(CartesianIndex, se)
         @test se_offsets == filter(i->!iszero(i), vec(CartesianIndices((-1:1, -1:1))))
         se_mask = @inferred strel(Bool, se)
         # not BitMatrix as SEBoxArray provides more information of what the SE is

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -247,3 +247,14 @@ end
     msg = "invalid structuring element data type: $(Vector{CartesianIndex})"
     @test_throws ErrorException(msg) strel_type(CartesianIndex[])
 end
+
+@testset "strel_size" begin
+    se = strel_diamond((5, 5), (1, ))
+    @test strel_size(se) == strel_size(collect(se)) == (3, 1)
+
+    se = strel_window((5, 5), (2, ))
+    @test strel_size(se) == strel_size(collect(se)) == (1, 3)
+
+    se = [CartesianIndex(-2, -2), CartesianIndex(1, 1)]
+    @test strel_size(se) == (5, 5)
+end

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -1,0 +1,249 @@
+@testset "strel" begin
+    @testset "offset to mask" begin
+        se = [CartesianIndex(-1), CartesianIndex(1)]
+        se_mask = @inferred strel(Bool, se)
+        @test se_mask == Bool[1, 1, 1]
+
+        se = [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
+        @test strel(se) === se
+        se_mask = @inferred strel(Bool, se)
+        @test se_mask == Bool[1 0 0; 0 1 0; 0 0 1]
+        # internally, Bool is converted to SEMask
+        se_mask = @inferred strel(ImageMorphology.SEMask{2}(), se)
+        @test se_mask == Bool[1 0 0; 0 1 0; 0 0 1]
+
+        se = CartesianIndices((-1:1, -1:1))
+        se_mask = @inferred strel(Bool, se)
+        @test se_mask == trues((3, 3))
+
+        se = CartesianIndices((1:2, -1:1))
+        se_mask = @inferred strel(Bool, se)
+        @test se_mask == Bool[0 0 0; 0 0 0; 0 1 0; 1 1 1; 1 1 1]
+
+        se = @inferred strel(Bool, CartesianIndex{2}[])
+        @test se == reshape(Bool[1], (1, 1)) # v1.7: Bool[1;;]
+
+        # invalid cases
+        se = [CartesianIndex(1), CartesianIndex(1, 1)]
+        @test_throws ErrorException strel(se)
+    end
+
+    @testset "mask to offset" begin
+        se = Bool[1, 0, 1]
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, se)
+        else
+            strel(CartesianIndex, se)
+        end
+        @test se_offsets == [CartesianIndex(-1,), CartesianIndex(1,)]
+        @test se_offsets == strel(CartesianIndex, Bool[1, 1, 1])
+
+        se = Bool[1 0 0; 0 1 0; 0 0 1]
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, se)
+        else
+            strel(CartesianIndex, se)
+        end
+        @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
+        # internally, CartesianIndex is converted to SEOffset
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(ImageMorphology.SEOffset{2}(), se)
+        else
+            strel(ImageMorphology.SEOffset{2}(), se)
+        end
+        @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
+
+        se = trues((3, 3))
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, se)
+        else
+            strel(CartesianIndex, se)
+        end
+        @test se_offsets == filter(x -> !iszero(x), vec(CartesianIndices((-1:1, -1:1))))
+
+        se = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, falses(3, 3))
+        else
+            strel(CartesianIndex, falses(3, 3))
+        end
+        @test isempty(se)
+    end
+
+    @testset "center point" begin
+        for se in [Bool[1 0 0; 0 1 0; 0 0 1], Bool[1 0 0; 0 0 0; 0 0 1]]
+            # center point is always excluded in offsets
+            se_offsets = if VERSION >= v"1.6"
+                @inferred strel(CartesianIndex, se)
+            else
+                strel(CartesianIndex, se)
+            end
+            @test se_offsets == [CartesianIndex(-1, -1), CartesianIndex(1, 1)]
+            # but included in mask
+            se_mask = @inferred strel(Bool, se_offsets)
+            @test se_mask == Bool[1 0 0; 0 1 0; 0 0 1]
+        end
+    end
+end
+
+@testset "strel_diamond" begin
+    @testset "N=1" begin
+        img = rand(5,)
+        se = @inferred strel_diamond(img)
+        @test se isa ImageMorphology.SEDiamondArray
+        @test eltype(se) == Bool
+        @test se == Bool[1, 1, 1]
+
+        se = @inferred strel_diamond((5,))
+        @test se == Bool[0, 1, 1, 1, 0]
+
+        se = @inferred strel_diamond((5,); r=2)
+        @test se == Bool[1, 1, 1, 1, 1]
+    end
+
+    @testset "N=2" begin
+        img = rand(5, 5)
+        se = @inferred strel_diamond(img)
+        @test se isa ImageMorphology.SEDiamondArray
+        @test eltype(se) == Bool
+        @test se == Bool[0 1 0; 1 1 1; 0 1 0]
+        @test se == strel_diamond((3, 3), (1, 2); r=1)
+        @test se == strel_diamond(img, (1, 2); r=1)
+
+        se = @inferred strel_diamond((3, 5))
+        @test se == Bool[0 0 1 0 0; 0 1 1 1 0; 0 0 1 0 0]
+
+        se = @inferred strel_diamond((3, 5), (1,))
+        @test se == Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0]
+
+        se = @inferred strel_diamond((3, 5), (2,))
+        @test se == Bool[0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0]
+
+        se = @inferred strel_diamond((3, 5); r=2)
+        @test se == Bool[0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0]
+    end
+
+    @testset "N=3" begin
+        img = rand(5, 5, 5)
+        se = @inferred strel_diamond(img)
+        @test se isa ImageMorphology.SEDiamondArray
+        @test eltype(se) == Bool
+        @test se[:, :, 1] == se[:, :, 3] == Bool[0 0 0; 0 1 0; 0 0 0]
+        @test se[:, :, 2] == strel_diamond((3, 3))
+
+        se = @inferred strel_diamond((3, 3, 3), (1, 2))
+        @test se[:, :, 1] == se[:, :, 3] == falses((3, 3))
+        @test se[:, :, 2] == strel_diamond((3, 3))
+    end
+
+    @testset "strel conversion" begin
+        se = strel_diamond((3, 3))
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, se)
+        else
+            strel(CartesianIndex, se)
+        end
+        @test se_offsets == [CartesianIndex(0, -1), CartesianIndex(-1, 0), CartesianIndex(1, 0), CartesianIndex(0, 1)]
+        se_mask = @inferred strel(Bool, se)
+        # not BitMatrix as SEDiamondArray provides more information of what the SE is
+        @test se_mask isa ImageMorphology.SEDiamondArray
+        @test se_mask === se
+    end
+
+    # edge cases
+    img = rand(5, 5)
+    err = ArgumentError("`size` length should be at least 2")
+    @test_throws err strel_diamond((3,), (1, 2,))
+    err = ArgumentError("all size should be odd number")
+    @test_throws err strel_diamond((2, 3))
+    err = ArgumentError("dims should be unique")
+    @test_throws err strel_diamond((3, 3), (1, 1))
+    err = ArgumentError("all `dims` values should be less than or equal to 2")
+    @test_throws err strel_diamond((3, 3), (5,))
+end
+
+@testset "strel_window" begin
+    @testset "N=1" begin
+        img = rand(5,)
+        se = @inferred strel_window(img)
+        @test se isa ImageMorphology.SEWindowArray
+        @test eltype(se) == Bool
+        @test se == Bool[1, 1, 1]
+
+        se = @inferred strel_window((5,))
+        @test se == Bool[0, 1, 1, 1, 0]
+
+        se = @inferred strel_window((5,); r=2)
+        @test se == Bool[1, 1, 1, 1, 1]
+    end
+
+    @testset "N=2" begin
+        img = rand(5, 5)
+        se = @inferred strel_window(img)
+        @test se isa ImageMorphology.SEWindowArray
+        @test eltype(se) == Bool
+        @test se == Bool[1 1 1; 1 1 1; 1 1 1]
+        @test se == strel_window((3, 3), (1, 2); r=1)
+        @test se == strel_window(img, (1, 2); r=1)
+
+        se = @inferred strel_window((3, 5))
+        @test se == Bool[0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0]
+
+        se = @inferred strel_window((3, 5), (1,))
+        @test se == Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0]
+
+        se = @inferred strel_window((3, 5), (2,))
+        @test se == Bool[0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0]
+
+        se = @inferred strel_window((3, 5); r=2)
+        @test se == Bool[1 1 1 1 1; 1 1 1 1 1; 1 1 1 1 1]
+    end
+
+    @testset "N=3" begin
+        img = rand(5, 5, 5)
+        se = @inferred strel_window(img)
+        @test se isa ImageMorphology.SEWindowArray
+        @test eltype(se) == Bool
+        @test se[:, :, 1] == se[:, :, 3] == trues((3, 3))
+        @test se[:, :, 2] == strel_window((3, 3))
+
+        se = @inferred strel_window((3, 3, 3), (1, 2))
+        @test se[:, :, 1] == se[:, :, 3] == falses((3, 3))
+        @test se[:, :, 2] == strel_window((3, 3))
+    end
+
+    @testset "strel conversion" begin
+        se = strel_window((3, 3))
+        se_offsets = if VERSION >= v"1.6"
+            @inferred strel(CartesianIndex, se)
+        else
+            strel(CartesianIndex, se)
+        end
+        @test se_offsets == filter(i->!iszero(i), vec(CartesianIndices((-1:1, -1:1))))
+        se_mask = @inferred strel(Bool, se)
+        # not BitMatrix as SEWindowArray provides more information of what the SE is
+        @test se_mask isa ImageMorphology.SEWindowArray
+        @test se_mask === se
+    end
+
+    # edge cases
+    img = rand(5, 5)
+    err = ArgumentError("`size` length should be at least 2")
+    @test_throws err strel_window((3,), (1, 2,))
+    err = ArgumentError("all size should be odd number")
+    @test_throws err strel_window((2, 3))
+    err = ArgumentError("dims should be unique")
+    @test_throws err strel_window((3, 3), (1, 1))
+    err = ArgumentError("all `dims` values should be less than or equal to 2")
+    @test_throws err strel_window((3, 3), (5,))
+end
+
+@testset "strel_type" begin
+    @test strel_type(strel_diamond((3, 3))) isa ImageMorphology.SEDiamond
+    @test strel_type(strel_window((3, 3))) isa ImageMorphology.SEWindow
+    @test strel_type([CartesianIndex(1, 2)]) isa ImageMorphology.SEOffset
+    @test strel_type(CartesianIndices((-1:1, -1:1))) isa ImageMorphology.SEOffset
+    @test strel_type(trues(3, 3)) isa ImageMorphology.SEMask
+
+    msg = "invalid structuring element data type: $(Vector{CartesianIndex})"
+    @test_throws ErrorException(msg) strel_type(CartesianIndex[])
+end

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -161,58 +161,58 @@ end
     @test_throws err strel_diamond((3, 3), (5,))
 end
 
-@testset "strel_window" begin
+@testset "strel_box" begin
     @testset "N=1" begin
         img = rand(5,)
-        se = @inferred strel_window(img)
-        @test se isa ImageMorphology.SEWindowArray
+        se = @inferred strel_box(img)
+        @test se isa ImageMorphology.SEBoxArray
         @test eltype(se) == Bool
         @test se == Bool[1, 1, 1]
 
-        se = @inferred strel_window((5,))
+        se = @inferred strel_box((5,))
         @test se == Bool[0, 1, 1, 1, 0]
 
-        se = @inferred strel_window((5,); r=2)
+        se = @inferred strel_box((5,); r=2)
         @test se == Bool[1, 1, 1, 1, 1]
     end
 
     @testset "N=2" begin
         img = rand(5, 5)
-        se = @inferred strel_window(img)
-        @test se isa ImageMorphology.SEWindowArray
+        se = @inferred strel_box(img)
+        @test se isa ImageMorphology.SEBoxArray
         @test eltype(se) == Bool
         @test se == Bool[1 1 1; 1 1 1; 1 1 1]
-        @test se == strel_window((3, 3), (1, 2); r=1)
-        @test se == strel_window(img, (1, 2); r=1)
+        @test se == strel_box((3, 3), (1, 2); r=1)
+        @test se == strel_box(img, (1, 2); r=1)
 
-        se = @inferred strel_window((3, 5))
+        se = @inferred strel_box((3, 5))
         @test se == Bool[0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0]
 
-        se = @inferred strel_window((3, 5), (1,))
+        se = @inferred strel_box((3, 5), (1,))
         @test se == Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0]
 
-        se = @inferred strel_window((3, 5), (2,))
+        se = @inferred strel_box((3, 5), (2,))
         @test se == Bool[0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0]
 
-        se = @inferred strel_window((3, 5); r=2)
+        se = @inferred strel_box((3, 5); r=2)
         @test se == Bool[1 1 1 1 1; 1 1 1 1 1; 1 1 1 1 1]
     end
 
     @testset "N=3" begin
         img = rand(5, 5, 5)
-        se = @inferred strel_window(img)
-        @test se isa ImageMorphology.SEWindowArray
+        se = @inferred strel_box(img)
+        @test se isa ImageMorphology.SEBoxArray
         @test eltype(se) == Bool
         @test se[:, :, 1] == se[:, :, 3] == trues((3, 3))
-        @test se[:, :, 2] == strel_window((3, 3))
+        @test se[:, :, 2] == strel_box((3, 3))
 
-        se = @inferred strel_window((3, 3, 3), (1, 2))
+        se = @inferred strel_box((3, 3, 3), (1, 2))
         @test se[:, :, 1] == se[:, :, 3] == falses((3, 3))
-        @test se[:, :, 2] == strel_window((3, 3))
+        @test se[:, :, 2] == strel_box((3, 3))
     end
 
     @testset "strel conversion" begin
-        se = strel_window((3, 3))
+        se = strel_box((3, 3))
         se_offsets = if VERSION >= v"1.6"
             @inferred strel(CartesianIndex, se)
         else
@@ -220,26 +220,26 @@ end
         end
         @test se_offsets == filter(i->!iszero(i), vec(CartesianIndices((-1:1, -1:1))))
         se_mask = @inferred strel(Bool, se)
-        # not BitMatrix as SEWindowArray provides more information of what the SE is
-        @test se_mask isa ImageMorphology.SEWindowArray
+        # not BitMatrix as SEBoxArray provides more information of what the SE is
+        @test se_mask isa ImageMorphology.SEBoxArray
         @test se_mask === se
     end
 
     # edge cases
     img = rand(5, 5)
     err = ArgumentError("`size` length should be at least 2")
-    @test_throws err strel_window((3,), (1, 2,))
+    @test_throws err strel_box((3,), (1, 2,))
     err = ArgumentError("all size should be odd number")
-    @test_throws err strel_window((2, 3))
+    @test_throws err strel_box((2, 3))
     err = ArgumentError("dims should be unique")
-    @test_throws err strel_window((3, 3), (1, 1))
+    @test_throws err strel_box((3, 3), (1, 1))
     err = ArgumentError("all `dims` values should be less than or equal to 2")
-    @test_throws err strel_window((3, 3), (5,))
+    @test_throws err strel_box((3, 3), (5,))
 end
 
 @testset "strel_type" begin
     @test strel_type(strel_diamond((3, 3))) isa ImageMorphology.SEDiamond
-    @test strel_type(strel_window((3, 3))) isa ImageMorphology.SEWindow
+    @test strel_type(strel_box((3, 3))) isa ImageMorphology.SEBox
     @test strel_type([CartesianIndex(1, 2)]) isa ImageMorphology.SEOffset
     @test strel_type(CartesianIndices((-1:1, -1:1))) isa ImageMorphology.SEOffset
     @test strel_type(trues(3, 3)) isa ImageMorphology.SEMask
@@ -252,7 +252,7 @@ end
     se = strel_diamond((5, 5), (1, ))
     @test strel_size(se) == strel_size(collect(se)) == (3, 1)
 
-    se = strel_window((5, 5), (2, ))
+    se = strel_box((5, 5), (2, ))
     @test strel_size(se) == strel_size(collect(se)) == (1, 3)
 
     se = [CartesianIndex(-2, -2), CartesianIndex(1, 1)]


### PR DESCRIPTION
This PR tries to unify the structuring element concept via `strel` function and a few internal trait types. For the proof of concept, will work on #11 and #63 on top of this.

This function converts from one structuring element representation to
the other. Currently, three structuring element representations are
supported:

- SEOffsets: Vector{CartesianIndex{N}}
- SEMask: BitArray{Bool}
~- SEAlias~

`MorphologySE` and the above subtypes are internal types. For user
interface, they are:

- Offsets: `strel(CartesianIndex, se)`
- Mask: `strel(Bool, se)`
~- Alias: `strel([T], symbol, N)`~

cc: @ThomasRetornaz 