### PR TITLE
add inbounds for extremefilt!

### DIFF
--- a/src/dilation_and_erosion.jl
+++ b/src/dilation_and_erosion.jl
@@ -234,7 +234,7 @@ end
 
 @noinline function _extremefilt!(A, select, Rpre, inds, Rpost)
     # TODO: improve the cache efficiency
-    for Ipost in Rpost, Ipre in Rpre
+    @inbounds for Ipost in Rpost, Ipre in Rpre
         # first element along dim
         i1 = first(inds)
         a2, a3 = A[Ipre, i1, Ipost], A[Ipre, i1+1, Ipost]


### PR DESCRIPTION
Since this internal function uses `axes(img)` to generate `Rpre`, `inds` and `RPost`, we can safely skip inbounds check here.