### PR TITLE
Force vscode auto format on save

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,14 @@
+style="blue"
+indent=4
+margin=140 # for most cases, let the devloper to wrap the lines manually
+whitespace_in_kwargs=false
+whitespace_ops_in_indices=true
+remove_extra_newlines=false
+trailing_comma=true
+always_for_in=true
+align_pair_arrow=true
+align_matrix=true
+align_assignment=true
+align_struct_field=true
+align_conditional=true
+join_lines_based_on_source=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.vscode
+
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[julia]": {
+        "editor.formatOnSave": true
+    }
+}

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -23,12 +23,14 @@ using .FeatureTransform
 include("deprecations.jl")
 
 export
+    # structuring_element.jl
     strel,
     strel_type,
     strel_size,
     strel_diamond,
     strel_box,
 
+    # operations
     dilate,
     dilate!,
     erode,
@@ -63,22 +65,36 @@ export
 
     # maxtree.jl
     MaxTree,
-    areas, boundingboxes, diameters,
-    area_opening, area_opening!, area_closing, area_closing!,
-    diameter_opening, diameter_opening!, diameter_closing, diameter_closing!,
-    local_maxima!, local_maxima, local_minima!, local_minima,
+    areas,
+    boundingboxes,
+    diameters,
+    area_opening,
+    area_opening!,
+    area_closing,
+    area_closing!,
+    diameter_opening,
+    diameter_opening!,
+    diameter_closing,
+    diameter_closing!,
+    local_maxima!,
+    local_maxima,
+    local_minima!,
+    local_minima,
 
     #feature_transform.jl
     feature_transform,
     distance_transform,
-
     clearborder
 
 function __init__()
     @require ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
         # morphological operations for ImageMeta
-        dilate(img::ImageMetadata.ImageMeta; kwargs...) = ImageMetadata.shareproperties(img, dilate!(copy(ImageMetadata.arraydata(img)); kwargs...))
-        erode(img::ImageMetadata.ImageMeta; kwargs...) = ImageMetadata.shareproperties(img, erode!(copy(ImageMetadata.arraydata(img)); kwargs...))
+        function dilate(img::ImageMetadata.ImageMeta; kwargs...)
+            return ImageMetadata.shareproperties(img, dilate!(copy(ImageMetadata.arraydata(img)); kwargs...))
+        end
+        function erode(img::ImageMetadata.ImageMeta; kwargs...)
+            return ImageMetadata.shareproperties(img, erode!(copy(ImageMetadata.arraydata(img)); kwargs...))
+        end
     end
 end
 

--- a/src/clearborder.jl
+++ b/src/clearborder.jl
@@ -13,21 +13,21 @@ Parameters:
 function clearborder(img::AbstractArray, width::Integer=1, background::Integer=0)
 
     for i in size(img)
-        if(width > i)
+        if (width > i)
             throw(ArgumentError("Border width must not be greater than size of the image."))
         end
     end
 
     connectivity = ntuple(i -> 3, ndims(img))
-    labels = label_components(img,trues(connectivity))
+    labels = label_components(img, trues(connectivity))
     number = maximum(labels) + 1
 
     dimensions = size(img)
     outerrange = CartesianIndices(map(i -> 1:i, dimensions))
-    innerrange = CartesianIndices(map(i -> 1+width:i-width, dimensions))
+    innerrange = CartesianIndices(map(i -> (1 + width):(i - width), dimensions))
 
     border_labels = Set{Int}()
-    for i in EdgeIterator(outerrange,innerrange)
+    for i in EdgeIterator(outerrange, innerrange)
         push!(border_labels, labels[i])
     end
 
@@ -36,7 +36,7 @@ function clearborder(img::AbstractArray, width::Integer=1, background::Integer=0
         if labels[itr] in border_labels
             new_img[itr] = background
         else
-        	new_img[itr] = img[itr]
+            new_img[itr] = img[itr]
         end
     end
 

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -4,11 +4,11 @@ chull = convexhull(img)
 ```
 Computes the convex hull of a binary image and returns the vertices of convex hull as a CartesianIndex array.
 """
-function convexhull(img::AbstractArray{T, 2}) where T<:Union{Bool,Gray{Bool}}
+function convexhull(img::AbstractArray{T,2}) where {T<:Union{Bool,Gray{Bool}}}
 
     function getboundarypoints(img)
         points = CartesianIndex{2}[]
-        for j = axes(img, 2)
+        for j in axes(img, 2)
             v = Base.view(img, :, j)
             i1 = findfirst(v)
             if i1 != nothing
@@ -19,73 +19,76 @@ function convexhull(img::AbstractArray{T, 2}) where T<:Union{Bool,Gray{Bool}}
                 end
             end
         end
-        points
+        return points
     end
 
     function right_oriented(ref, a, b)
-        (a[2]-ref[2])*(b[1]-ref[1])-(b[2]-ref[2])*(a[1]-ref[1])<0
+        return (a[2] - ref[2]) * (b[1] - ref[1]) - (b[2] - ref[2]) * (a[1] - ref[1]) < 0
     end
 
     function collinear(a, b, c)
-        (a[2]-c[2])*(b[1]-c[1])-(b[2]-c[2])*(a[1]-c[1])==0
+        return (a[2] - c[2]) * (b[1] - c[1]) - (b[2] - c[2]) * (a[1] - c[1]) == 0
     end
 
-    dist2(a, b) = sum(abs2, (a-b).I)
+    dist2(a, b) = sum(abs2, (a - b).I)
 
     function angularsort!(points, ref, img)
         last_point = ref
 
         for i in eachindex(points)
-            if points[i]==last_point
+            if points[i] == last_point
                 deleteat!(points, i)
                 break
             end
         end
 
-        sort!(points, lt=(a, b) -> right_oriented(last_point, a, b))
+        sort!(points; lt=(a, b) -> right_oriented(last_point, a, b))
 
-        i=0
-        while i<=length(points)
-            i=i+1
-            if i+1>length(points)
+        i = 0
+        while i <= length(points)
+            i = i + 1
+            if i + 1 > length(points)
                 break
             end
 
-            if collinear(last_point, points[i], points[i+1])
-                if dist2(last_point, points[i]) < dist2(last_point, points[i+1])
+            if collinear(last_point, points[i], points[i + 1])
+                if dist2(last_point, points[i]) < dist2(last_point, points[i + 1])
                     deleteat!(points, i)
                 else
-                    deleteat!(points, i+1)
+                    deleteat!(points, i + 1)
                 end
-                i=i-1
+                i = i - 1
             end
         end
     end
 
     # Used Graham scan algorithm
 
-    points=getboundarypoints(img)
-    last_point=CartesianIndex(map(r->first(r)-1, axes(img)))
+    points = getboundarypoints(img)
+    last_point = CartesianIndex(map(r -> first(r) - 1, axes(img)))
     for point in points
-        if point[2]>last_point[2] || (point[2]==last_point[2] && point[1]>last_point[1])
-            last_point=point
+        if point[2] > last_point[2] || (point[2] == last_point[2] && point[1] > last_point[1])
+            last_point = point
         end
     end
     angularsort!(points, last_point, img)
 
-    n_points=length(points)
+    n_points = length(points)
 
-    if n_points<3
+    if n_points < 3
         error("Not enough points to compute convex hull.")
     end
 
-    convex_hull=CartesianIndex{2}[]
+    convex_hull = CartesianIndex{2}[]
     push!(convex_hull, last_point)
     push!(convex_hull, points[1])
     push!(convex_hull, points[2])
 
     for i in 3:n_points
-        while (right_oriented(convex_hull[end],convex_hull[end-1], points[i]) || collinear(convex_hull[end],convex_hull[end-1], points[i]))
+        while (
+            right_oriented(convex_hull[end], convex_hull[end - 1], points[i]) ||
+            collinear(convex_hull[end], convex_hull[end - 1], points[i])
+        )
             pop!(convex_hull)
         end
         push!(convex_hull, points[i])

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,4 @@
+#! format: off
 @deprecate label_components(A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0) label_components(A; bkg=bkg, dims=region)
 @deprecate label_components(A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}   label_components(A, connectivity; bkg=bkg)
 @deprecate label_components!(out::AbstractArray{Int}, A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0)  label_components!(out, A; bkg=bkg, dims=region)

--- a/src/dilation_and_erosion.jl
+++ b/src/dilation_and_erosion.jl
@@ -221,15 +221,15 @@ julia> extremefilt!(.!box, |) .& box
 """
 function extremefilt!(A::AbstractArray, select::Function; dims=coords_spatial(A))
     inds = axes(A)
-    for d = 1:ndims(A)
+    for d in 1:ndims(A)
         if size(A, d) == 1 || d ∉ dims
             continue
         end
-        Rpre = CartesianIndices(inds[1:d-1])
-        Rpost = CartesianIndices(inds[d+1:end])
+        Rpre = CartesianIndices(inds[1:(d - 1)])
+        Rpost = CartesianIndices(inds[(d + 1):end])
         _extremefilt!(A, select, Rpre, inds[d], Rpost)
     end
-    A
+    return A
 end
 
 @noinline function _extremefilt!(A, select, Rpre, inds, Rpost)
@@ -237,18 +237,18 @@ end
     @inbounds for Ipost in Rpost, Ipre in Rpre
         # first element along dim
         i1 = first(inds)
-        a2, a3 = A[Ipre, i1, Ipost], A[Ipre, i1+1, Ipost]
+        a2, a3 = A[Ipre, i1, Ipost], A[Ipre, i1 + 1, Ipost]
         A[Ipre, i1, Ipost] = select(a2, a3)
         # interior along dim
-        for i = i1+2:last(inds)
+        for i in (i1 + 2):last(inds)
             a1, a2 = a2, a3
             a3 = A[Ipre, i, Ipost]
-            A[Ipre, i-1, Ipost] = select(select(a1, a2), a3)
+            A[Ipre, i - 1, Ipost] = select(select(a1, a2), a3)
         end
         # last element along dim
         A[Ipre, last(inds), Ipost] = select(a2, a3)
     end
-    A
+    return A
 end
 
 """
@@ -396,7 +396,9 @@ julia> morphogradient(img)
  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 ```
 """
-morphogradient(img::AbstractArray; kwargs...) = dilate(img; kwargs...) - erode(img; kwargs...)
+function morphogradient(img::AbstractArray; kwargs...)
+    return dilate(img; kwargs...) - erode(img; kwargs...)
+end
 
 """
 `imgml = morpholaplace(img; dims=coords_spatial(img))` performs `Morphological Laplacian` of an image,
@@ -427,4 +429,6 @@ julia> morpholaplace(img)
  0.0  0.0   0.0   0.0   0.0  0.0  0.0
 ```
 """
-morpholaplace(img::AbstractArray; kwargs...) = dilate(img; kwargs...) + erode(img; kwargs...) - 2img
+function morpholaplace(img::AbstractArray; kwargs...)
+    return dilate(img; kwargs...) + erode(img; kwargs...) - 2img
+end

--- a/src/feature_transform.jl
+++ b/src/feature_transform.jl
@@ -30,9 +30,11 @@ See also: [`distance_transform`](@ref).
 Transforms of Binary Images in Arbitrary Dimensions' [Maurer et al.,
 2003] (DOI: 10.1109/TPAMI.2003.1177156)
 """
-function feature_transform(img::AbstractArray{<:Union{Bool,AbstractGray{Bool}},N};
-                           weights::Union{Nothing,NTuple{N}}=nothing,
-                           nthreads::Int = length(img) < 1000 ? 1 : Threads.nthreads()) where N
+function feature_transform(
+    img::AbstractArray{<:Union{Bool,AbstractGray{Bool}},N};
+    weights::Union{Nothing,NTuple{N}}=nothing,
+    nthreads::Int=length(img) < 1000 ? 1 : Threads.nthreads(),
+) where {N}
     nthreads > 0 || error("the number of threads must be positive, got $nthreads")
     N == 0 && return reshape([CartesianIndex()])
     # Allocate the output
@@ -48,14 +50,14 @@ function feature_transform(img::AbstractArray{<:Union{Bool,AbstractGray{Bool}},N
         # Finish the last dimension (for multithreading, we avoid doing it in computeft!)
         finishft!(F, img, axsimg, CartesianIndex(), weights, tmp)
     else
-        tmps = [typeof(drft)[] for _ = 1:nthreads] # temporary storage (one per thread)
+        tmps = [typeof(drft)[] for _ in 1:nthreads] # temporary storage (one per thread)
         saxs = SplitAxes(axsimg, nthreads - 0.2)   # give main thread less work since it also schedules the others
-        tasks = [Threads.@spawn computeft!(F, img, saxs[i], CartesianIndex(), weights, tmps[i]) for i = 2:nthreads]
+        tasks = [Threads.@spawn computeft!(F, img, saxs[i], CartesianIndex(), weights, tmps[i]) for i in 2:nthreads]
         computeft!(F, img, saxs[1], CartesianIndex(), weights, tmps[1])
         foreach(wait, tasks)
         # Finish the last dimension
-        saxs1 = SplitAxes(axsimg[1:N-1], nthreads - 0.2)
-        tasks = [Threads.@spawn finishft!(F, img, (saxs1[i]..., axsimg[end]), CartesianIndex(), weights, tmps[i]) for i = 2:nthreads]
+        saxs1 = SplitAxes(axsimg[1:(N - 1)], nthreads - 0.2)
+        tasks = [Threads.@spawn finishft!(F, img, (saxs1[i]..., axsimg[end]), CartesianIndex(), weights, tmps[i]) for i in 2:nthreads]
         finishft!(F, img, (saxs1[1]..., axsimg[end]), CartesianIndex(), weights, tmps[1])
         foreach(wait, tasks)
     end
@@ -73,7 +75,7 @@ default value of `nothing` is equivalent to `w=(1,1,...)`.
 
 See also: [`feature_transform`](@ref).
 """
-function distance_transform(F::AbstractArray{CartesianIndex{N},N}, w::Union{Nothing,NTuple{N}}=nothing) where N
+function distance_transform(F::AbstractArray{CartesianIndex{N},N}, w::Union{Nothing,NTuple{N}}=nothing) where {N}
     # To allocate the proper output type, compute the distance for one element
     R = CartesianIndices(axes(F))
     dst = wnorm2(zero(eltype(R)), w)
@@ -85,17 +87,17 @@ function distance_transform(F::AbstractArray{CartesianIndex{N},N}, w::Union{Noth
         D[i] = fi == ∅ ? Inf : sqrt(wnorm2(fi - i, w))
     end
 
-    D
+    return D
 end
 
 # This recursive implementation computes the feature transform, other than for finishing the
 # work along the final axis (axis `N` for an `N` dimensional array).
 # Omission of the final axis makes it easy to implement multithreading.
 # You can finish the final axis with a call to `finishft!` with `jpost = CartesianIndex()`.
-function computeft!(F, img, axsimg, jpost::CartesianIndex{K}, pixelspacing, tmp) where K
+function computeft!(F, img, axsimg, jpost::CartesianIndex{K}, pixelspacing, tmp) where {K}
     # tmp is workspace for voronoift!
     ∅ = nullindex(F)                             # sentinel position
-    if K == ndims(img)-1                           # innermost loop (d=1 case, line 1)
+    if K == ndims(img) - 1                           # innermost loop (d=1 case, line 1)
         # Fig. 2, lines 2-8
         @inbounds @simd for i1 in axes(img, 1)
             F[i1, jpost] = gray(img[i1, jpost]) ? CartesianIndex(i1, jpost) : ∅
@@ -120,7 +122,7 @@ function finishft!(F, img, axsimg, jpost, pixelspacing, tmp)
 end
 
 function voronoift!(F, img, jpre, jpost, pixelspacing, tmp)
-    d = length(jpre)+1   # axis to work along
+    d = length(jpre) + 1   # axis to work along
     ∅ = nullindex(F)
     empty!(tmp)
     for i in axes(img, d)
@@ -132,7 +134,7 @@ function voronoift!(F, img, jpre, jpost, pixelspacing, tmp)
             if length(tmp) < 2
                 push!(tmp, fidist)
             else
-                @inbounds while length(tmp) >= 2 && removeft(tmp[end-1], tmp[end], fidist)
+                @inbounds while length(tmp) >= 2 && removeft(tmp[end - 1], tmp[end], fidist)
                     pop!(tmp)
                 end
                 push!(tmp, fidist)
@@ -146,10 +148,10 @@ function voronoift!(F, img, jpre, jpost, pixelspacing, tmp)
     @inbounds fthis = tmp[l].fi
     for i in axes(img, d)
         xi = CartesianIndex(jpre, i, jpost)
-        d2this = wnorm2(xi-fthis, pixelspacing)
+        d2this = wnorm2(xi - fthis, pixelspacing)
         while l < nS
-            @inbounds fnext = tmp[l+1].fi
-            d2next = wnorm2(xi-fnext, pixelspacing)
+            @inbounds fnext = tmp[l + 1].fi
+            d2next = wnorm2(xi - fnext, pixelspacing)
             if d2this > d2next
                 d2this, fthis = d2next, fnext
                 l += 1
@@ -159,7 +161,7 @@ function voronoift!(F, img, jpre, jpost, pixelspacing, tmp)
         end
         @inbounds F[xi] = fthis
     end
-    F
+    return F
 end
 
 ## Utilities
@@ -183,15 +185,16 @@ tuple with the same number of coordiantes as `fi`.
 function DistRFT(fi::CartesianIndex, w, jpre::CartesianIndex, jpost::CartesianIndex)
     d2pre, ipost, wpost = dist2pre(fi.I, w, jpre.I)
     d2post = wnorm2(CartesianIndex(ipost) - jpost, wpost)
-    @inbounds fid = fi[length(jpre)+1]
-    DistRFT(fi, d2pre + d2post, fid)
+    @inbounds fid = fi[length(jpre) + 1]
+    return DistRFT(fi, d2pre + d2post, fid)
 end
-DistRFT(fi::CartesianIndex, w, jpre::Tuple, jpost::Tuple) =
-    DistRFT(fi, w, CartesianIndex(jpre), CartesianIndex(jpost))
+function DistRFT(fi::CartesianIndex, w, jpre::Tuple, jpost::Tuple)
+    return DistRFT(fi, w, CartesianIndex(jpre), CartesianIndex(jpost))
+end
 
 @inline function removeft(u, v, w)
-    a, b, c = v.d-u.d, w.d-v.d, w.d-u.d
-    c*v.dist2 - b*u.dist2 - a*w.dist2 > a*b*c
+    a, b, c = v.d - u.d, w.d - v.d, w.d - u.d
+    return c * v.dist2 - b * u.dist2 - a * w.dist2 > a * b * c
 end
 
 """
@@ -204,10 +207,10 @@ _truncatet(out, inds::NTuple{N}, j::CartesianIndex{N}) where {N} = Base.front(ou
 @inline _truncatet(out, inds, j) = _truncatet((out..., inds[1]), Base.tail(inds), j)
 
 if VERSION < v"1.1"
-    nullindex(A::AbstractArray{T,N}) where {T,N} = typemin(Int)*one(CartesianIndex{N})
+    nullindex(A::AbstractArray{T,N}) where {T,N} = typemin(Int) * one(CartesianIndex{N})
 else
     # This is the proper implementation
-    nullindex(A::AbstractArray{T,N}) where {T,N} = typemin(Int)*oneunit(CartesianIndex{N})
+    nullindex(A::AbstractArray{T,N}) where {T,N} = typemin(Int) * oneunit(CartesianIndex{N})
 end
 
 """
@@ -216,10 +219,10 @@ end
 Compute `∑ (w[i]*x[i])^2`.  Specifying `nothing` for `w` is equivalent to `w = (1,1,...)`.
 """
 wnorm2(x::CartesianIndex, w) = _wnorm2(0, x.I, w)
-_wnorm2(s, ::Tuple{}, ::Nothing)    = s
+_wnorm2(s, ::Tuple{}, ::Nothing) = s
 _wnorm2(s, ::Tuple{}, ::Tuple{}) = s
 @inline _wnorm2(s, x, w::Nothing) = _wnorm2(s + sqr(x[1]), Base.tail(x), w)
-@inline _wnorm2(s, x, w) = _wnorm2(s + sqr(w[1]*x[1]), Base.tail(x), Base.tail(w))
+@inline _wnorm2(s, x, w) = _wnorm2(s + sqr(w[1] * x[1]), Base.tail(x), Base.tail(w))
 
 """
     dist2pre(x, w, jpre) -> s, xpost, wpost
@@ -230,10 +233,14 @@ element `length(jpre)+1`).
 """
 dist2pre(x::Tuple, w, jpre) = _dist2pre(0, x, w, jpre)
 _dist2pre(s, x, w::Nothing, ::Tuple{}) = s, Base.tail(x), w
-_dist2pre(s, x, w,       ::Tuple{}) = s, Base.tail(x), Base.tail(w)
-@inline _dist2pre(s, x, w::Nothing, jpre) = _dist2pre(s + sqr(x[1]-jpre[1]), Base.tail(x), w, Base.tail(jpre))
-@inline _dist2pre(s, x, w, jpre) = _dist2pre(s + sqr(w[1]*(x[1]-jpre[1])), Base.tail(x), Base.tail(w), Base.tail(jpre))
+_dist2pre(s, x, w, ::Tuple{}) = s, Base.tail(x), Base.tail(w)
+@inline function _dist2pre(s, x, w::Nothing, jpre)
+    return _dist2pre(s + sqr(x[1] - jpre[1]), Base.tail(x), w, Base.tail(jpre))
+end
+@inline function _dist2pre(s, x, w, jpre)
+    return _dist2pre(s + sqr(w[1] * (x[1] - jpre[1])), Base.tail(x), Base.tail(w), Base.tail(jpre))
+end
 
-@inline sqr(x) = x*x
+@inline sqr(x) = x * x
 
 end # module

--- a/src/imfill.jl
+++ b/src/imfill.jl
@@ -35,22 +35,26 @@ julia> .!(ans)
  0  0  1  1  0  0
 ```
 """
-imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, connectivity::AbstractArray{Bool}) =
-    _imfill(img, interval, label_components(img,connectivity))
-imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}; dims=coords_spatial(img)) =
-    _imfill(img, interval, label_components(img; dims=dims))
-imfill(img::AbstractArray{Bool}, interval, args...; kwargs...) =
-    imfill(img, (minimum(interval)::Real, maximum(interval)::Real), args...; kwargs...)
+function imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, connectivity::AbstractArray{Bool})
+    return _imfill(img, interval, label_components(img, connectivity))
+end
+function imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}; dims=coords_spatial(img))
+    return _imfill(img, interval, label_components(img; dims=dims))
+end
+function imfill(img::AbstractArray{Bool}, interval, args...; kwargs...)
+    return imfill(img, (minimum(interval)::Real, maximum(interval)::Real), args...; kwargs...)
+end
 
 function _imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, labels)
     if interval[1] > interval[2] || interval[1] < 0 || interval[2] < 0
-        throw(DomainError(interval,"Interval must be non-negative and in format (min_range,max_range)"))
+        msg = "Interval must be non-negative and in format (min_range,max_range)"
+        throw(DomainError(interval, msg))
     end
     count_labels = component_lengths(labels)
 
     new_img = similar(img)
     for ind in eachindex(img)
-        if img[ind] == true && interval[1] <= count_labels[labels[ind]+1] <= interval[2]
+        if img[ind] == true && interval[1] <= count_labels[labels[ind] + 1] <= interval[2]
             new_img[ind] = false
         else
             new_img[ind] = img[ind]
@@ -58,4 +62,4 @@ function _imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, labels)
     end
 
     return new_img
- end
+end

--- a/src/isboundary.jl
+++ b/src/isboundary.jl
@@ -8,10 +8,7 @@ over which to discover boundaries.
 
 See out-of-place version, [`isboundary`](@ref), for examples.
 """
-function isboundary!(img::AbstractArray{Bool,N};
-                         background=false,
-                         kwargs...
-                        ) where N
+function isboundary!(img::AbstractArray{Bool,N}; background=false, kwargs...) where {N}
     # Find regions where there is at least one background pixel
     # centered on a foreground pixel
     if background == true
@@ -31,22 +28,21 @@ function isboundary!(img::AbstractArray{Bool,N};
         # background is neither true or false, use more generic algorithm
         background = Int8(-1) # Any value other than true or false will do
         #allequal(x,y) = ifelse(x == y, x, background)
-        allequal(x,y) = x == y ? x : background
+        allequal(x, y) = x == y ? x : background
         # the entire image is the foreground
         img .= (extremefilt!(Int8.(img), allequal; kwargs...) .== background)
     end
     return img
 end
-function isboundary!(img::AbstractArray{T};
-                          background = zero(T),
-                          kwargs...) where T
+function isboundary!(img::AbstractArray{T}; background=zero(T), kwargs...) where {T}
     # Find regions where that are not homogeneous (all equal)
     # centered on a foreground pixel
     # background_img = img .== background
     # foreground_img = img .!= background
     #allequal(x,y) = ifelse(x == y, x, background)
-    allequal(x,y) = x == y ? x : background
-    img .= (extremefilt!(copy(img), allequal; kwargs...) .== background) .& (img .!= background)
+    allequal(x, y) = x == y ? x : background
+    m = extremefilt!(copy(img), allequal; kwargs...)
+    img .= (m .== background) .& (img .!= background)
     # Alternatively, with ImageFiltering.jl
     # allequal(x) = all(==(first(x)), @view(x[2:end]))
     # .!mapwindow(allequal, A, (3,3)) .& (A .!= background)
@@ -168,11 +164,8 @@ julia> isboundary(A .!= 0; dims = 2)
  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 ```
 """
-function isboundary(img::AbstractArray{T};
-                         background = zero(T),
-                         kwargs...
-                        ) where T
-    isboundary!(copy(img); background = background, kwargs...)
+function isboundary(img::AbstractArray{T}; background=zero(T), kwargs...) where {T}
+    return isboundary!(copy(img); background=background, kwargs...)
 end
 
 ## Alternate implementations using dilate and erode
@@ -215,10 +208,7 @@ function isboundary_thick_dilate_erode(img::AbstractArray; kwargs...)
     # https://github.com/scikit-image/scikit-image/blob/d44ceda6241cb23a22dc8abf09a05090ed14da7f/skimage/segmentation/boundaries.py#L165-L167
     return dilate(img; kwargs...) .!= erode(img; kwargs...)
 end
-function isboundary_dilate_erode(img::AbstractArray{T};
-                                      background = zero(T),
-                                      kwargs...
-                                     ) where T
+function isboundary_dilate_erode(img::AbstractArray{T}; background=zero(T), kwargs...) where {T}
     # https://github.com/scikit-image/scikit-image/blob/d44ceda6241cb23a22dc8abf09a05090ed14da7f/skimage/segmentation/boundaries.py#L165-L170
     thick_boundaries = isboundary_thick_dilate_erode(img; kwargs...)
     foreground_img = img .!= background

--- a/src/thinning.jl
+++ b/src/thinning.jl
@@ -25,31 +25,33 @@ See also: [`GuoAlgo`](@ref)
 """
 function thinning(img::AbstractArray{Bool}; algo::ThinAlgo=GuoAlgo())
     # dispatch appropriate implementation
-    thinning_impl(img, algo)
+    return thinning_impl(img, algo)
 end
 
 function thinning_impl(img::AbstractArray{Bool,2}, algo::GuoAlgo)
     # pad input image
-    prev = falses(size(img).+2)
-    prev[2:end-1,2:end-1] = img
+    prev = falses(size(img) .+ 2)
+    prev[2:(end - 1), 2:(end - 1)] = img
 
     # preallocate memory for the mask
     mask = falses(size(prev))
 
     # perform single iteration
-    it = 1; curr = copy(prev)
+    it = 1
+    curr = copy(prev)
     guo_iteration!(mask, curr, isodd(it))
     curr[mask] .= false
 
     # loop if necessary
     while prev != curr
-        it += 1; prev .= curr
+        it += 1
+        prev .= curr
         guo_iteration!(mask, curr, isodd(it))
         curr[mask] .= false
     end
 
     # unpad result
-    curr[2:end-1,2:end-1]
+    return curr[2:(end - 1), 2:(end - 1)]
 end
 
 # update mask with Guo iteration on padded image
@@ -58,16 +60,16 @@ function guo_iteration!(mask::AbstractArray{Bool,2}, img::AbstractArray{Bool,2},
     mask .= false
 
     # loop over pixels and update mask
-    @inbounds for j=2:size(img,2)-1, i=2:size(img,1)-1
-        img[i,j] || continue
-        p1 = img[i-1,j-1]
-        p2 = img[i-1,j]
-        p3 = img[i-1,j+1]
-        p4 = img[i,j+1]
-        p5 = img[i+1,j+1]
-        p6 = img[i+1,j]
-        p7 = img[i+1,j-1]
-        p8 = img[i,j-1]
+    @inbounds for j in 2:(size(img, 2) - 1), i in 2:(size(img, 1) - 1)
+        img[i, j] || continue
+        p1 = img[i - 1, j - 1]
+        p2 = img[i - 1, j]
+        p3 = img[i - 1, j + 1]
+        p4 = img[i, j + 1]
+        p5 = img[i + 1, j + 1]
+        p6 = img[i + 1, j]
+        p7 = img[i + 1, j - 1]
+        p8 = img[i, j - 1]
         C = (!p2 && (p3 || p4)) + (!p4 && (p5 || p6)) + (!p6 && (p7 || p8)) + (!p8 && (p1 || p2))
         N1 = (p1 || p2) + (p3 || p4) + (p5 || p6) + (p7 || p8)
         N2 = (p2 || p3) + (p4 || p5) + (p6 || p7) + (p8 || p1)
@@ -78,7 +80,7 @@ function guo_iteration!(mask::AbstractArray{Bool,2}, img::AbstractArray{Bool,2},
             O = (p6 || p7 || !p1) && p8
         end
         if C == 1 && (2 ≤ N ≤ 3) && !O
-            mask[i,j] = true
+            mask[i, j] = true
         end
     end
 end

--- a/test/clearborder.jl
+++ b/test/clearborder.jl
@@ -1,65 +1,82 @@
 @testset "clearborder" begin
     #Case when given border width is more than image size
-    img = [1 0 1 1 1 1
-            0 1 1 1 0 0
-            1 1 0 0 0 1
-            0 1 0 1 0 1
-            1 1 0 0 0 1
-            0 0 1 1 0 0]
-    @test_throws ArgumentError clearborder(img,7)
+    img = [
+        1 0 1 1 1 1
+         0 1 1 1 0 0
+         1 1 0 0 0 1
+         0 1 0 1 0 1
+         1 1 0 0 0 1
+         0 0 1 1 0 0
+    ]
+    @test_throws ArgumentError clearborder(img, 7)
 
     #Normal Case
-    img = [0 0 0 0 0 0 0 1 0
-            0 0 0 0 1 0 0 0 0
-            1 0 0 1 0 1 0 0 0
-            0 0 1 1 1 1 1 0 0
-            0 1 1 1 1 1 1 1 0
-            0 0 0 0 0 0 0 0 0]
+    img = [
+        0 0 0 0 0 0 0 1 0
+         0 0 0 0 1 0 0 0 0
+         1 0 0 1 0 1 0 0 0
+         0 0 1 1 1 1 1 0 0
+         0 1 1 1 1 1 1 1 0
+         0 0 0 0 0 0 0 0 0
+    ]
     cleared_img = clearborder(img)
     check_img = copy(img)
-    check_img[3,1] = 0
-    check_img[1,8] = 0
+    check_img[3, 1] = 0
+    check_img[1, 8] = 0
     @test cleared_img == check_img
 
-    cleared_img = clearborder(img,2)
+    cleared_img = clearborder(img, 2)
     @test cleared_img == fill!(similar(img), zero(eltype(img)))
 
-    cleared_img = clearborder(img,2,10)
-    @test cleared_img == 10*fill!(similar(img), one(eltype(img)))
+    cleared_img = clearborder(img, 2, 10)
+    @test cleared_img == 10 * fill!(similar(img), one(eltype(img)))
 
     #Multidimentional Case
-    img = cat([0 0 0 0;
-                    0 0 0 0;
-                    0 0 0 0;
-                    1 0 0 0],
-                [0 0 0 0;
-                    0 1 1 0;
-                    0 0 1 0;
-                    0 0 0 0],
-                [0 0 0 0;
-                    0 0 0 0;
-                    0 0 0 0;
-                    0 0 0 0], dims=3)
+    img = cat(
+        [
+            0 0 0 0
+                 0 0 0 0
+                 0 0 0 0
+                 1 0 0 0
+        ],
+        [
+            0 0 0 0
+               0 1 1 0
+               0 0 1 0
+               0 0 0 0
+        ],
+        [
+            0 0 0 0
+               0 0 0 0
+               0 0 0 0
+               0 0 0 0
+        ];
+        dims=3,
+    )
     cleared_img = clearborder(img)
     check_img = copy(img)
-    check_img[4,1,1] = 0
+    check_img[4, 1, 1] = 0
     @test cleared_img == check_img
 
-    cleared_img = clearborder(img,2)
+    cleared_img = clearborder(img, 2)
     @test cleared_img == fill!(similar(img), zero(eltype(img)))
 
-    cleared_img = clearborder(img,2,10)
-    @test cleared_img == 10*fill!(similar(img), one(eltype(img)))
+    cleared_img = clearborder(img, 2, 10)
+    @test cleared_img == 10 * fill!(similar(img), one(eltype(img)))
 
     #Grayscale input image Case
-    img = [1 2 3 1 2
-            3 3 5 4 2
-            3 4 5 4 2
-            3 3 2 1 2]
+    img = [
+        1 2 3 1 2
+         3 3 5 4 2
+         3 4 5 4 2
+         3 3 2 1 2
+    ]
     cleared_img = clearborder(img)
-    check_img = [0 0 0 0 0
-                    0 0 5 4 0
-                    0 4 5 4 0
-                    0 0 0 0 0]
+    check_img = [
+        0 0 0 0 0
+           0 0 5 4 0
+           0 4 5 4 0
+           0 0 0 0 0
+    ]
     @test cleared_img == check_img
 end

--- a/test/connected.jl
+++ b/test/connected.jl
@@ -1,28 +1,43 @@
 @testset "Label components" begin
-    A = [true  true  false true;
-         true  false true  true]
-    lbltarget = [1 1 0 2;
-                 1 0 2 2]
-    lbltarget1 = [1 2 0 4;
-                  1 0 3 4]
+    A = [
+        true  true  false true
+        true  false true  true
+    ]
+    lbltarget = [
+        1 1 0 2
+        1 0 2 2
+    ]
+    lbltarget1 = [
+        1 2 0 4
+        1 0 3 4
+    ]
     @test label_components(A) == lbltarget
     @test label_components(A; dims=:) == lbltarget
     @test label_components(A; dims=1) == lbltarget1
-    connectivity = [false true  false;
-                    true  false true;
-                    false true  false]
+    connectivity = [
+        false true  false
+        true  false true
+        false true  false
+    ]
     @test label_components(A, connectivity) == lbltarget
-    connectivity = trues(3,3)
-    lbltarget2 = [1 1 0 1;
-                  1 0 1 1]
+    connectivity = trues(3, 3)
+    lbltarget2 = [
+        1 1 0 1
+        1 0 1 1
+    ]
     @test label_components(A, connectivity) == lbltarget2
-    @test component_boxes(lbltarget) == Vector{Tuple}[[(1,2),(2,3)],[(1,1),(2,2)],[(1,3),(2,4)]]
-    @test component_lengths(lbltarget) == [2,3,3]
-    @test component_indices(lbltarget) == Array{Int}[[4,5],[1,2,3],[6,7,8]]
-    @test component_subscripts(lbltarget) == Array{Tuple}[[(2,2),(1,3)],[(1,1),(2,1),(1,2)],[(2,3),(1,4),(2,4)]]
-    @test @inferred(component_centroids(lbltarget)) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
+    @test component_boxes(lbltarget) ==
+        Vector{Tuple}[[(1, 2), (2, 3)], [(1, 1), (2, 2)], [(1, 3), (2, 4)]]
+    @test component_lengths(lbltarget) == [2, 3, 3]
+    @test component_indices(lbltarget) == Array{Int}[[4, 5], [1, 2, 3], [6, 7, 8]]
+    @test component_subscripts(lbltarget) ==
+        Array{Tuple}[[(2, 2), (1, 3)], [(1, 1), (2, 1), (1, 2)], [(2, 3), (1, 4), (2, 4)]]
+    @test @inferred(component_centroids(lbltarget)) ==
+        Tuple[(1.5, 2.5), (4 / 3, 4 / 3), (5 / 3, 11 / 3)]
 
     @test label_components!(zeros(UInt8, 240), trues(240); dims=()) == 1:240
-    @test_throws ErrorException("labels exhausted, use a larger integer type") label_components!(zeros(UInt8, 260), trues(260); dims=())
+    @test_throws ErrorException("labels exhausted, use a larger integer type") label_components!(
+        zeros(UInt8, 260), trues(260); dims=()
+    )
     @test label_components!(zeros(UInt16, 260), trues(260); dims=()) == 1:260
 end

--- a/test/convexhull.jl
+++ b/test/convexhull.jl
@@ -1,36 +1,58 @@
 @testset "Convex Hull" begin
     A = zeros(50, 30)
-    A= convert(Array{Bool}, A)
-    A[25,1]=1
-    A[1,10]=1
-    A[10,10]=1
-    A[10,30]=1
-    A[40,30]=1
-    A[40,10]=1
-    A[50,10]=1
+    A = convert(Array{Bool}, A)
+    A[25, 1] = 1
+    A[1, 10] = 1
+    A[10, 10] = 1
+    A[10, 30] = 1
+    A[40, 30] = 1
+    A[40, 10] = 1
+    A[50, 10] = 1
     B = @inferred convexhull(A)
     C = CartesianIndex{}[]
-    push!(C, CartesianIndex{}(25,1))
-    push!(C, CartesianIndex{}(1,10))
-    push!(C, CartesianIndex{}(10,30))
-    push!(C, CartesianIndex{}(40,30))
-    push!(C, CartesianIndex{}(50,10))
-    @test typeof(B)==Array{CartesianIndex{2},1}
-    @test sort(B)==sort(C)
+    push!(C, CartesianIndex{}(25, 1))
+    push!(C, CartesianIndex{}(1, 10))
+    push!(C, CartesianIndex{}(10, 30))
+    push!(C, CartesianIndex{}(40, 30))
+    push!(C, CartesianIndex{}(50, 10))
+    @test typeof(B) == Array{CartesianIndex{2},1}
+    @test sort(B) == sort(C)
 
-    A = [0.0, 0.0, 1.0, 0.0, 0.0,
-         0.0, 1.0, 1.0, 0.0, 0.0,
-         1.0, 0.0, 0.0, 1.0, 1.0,
-         0.0, 0.0, 0.0, 0.0, 0.0,
-         0.0, 0.0, 1.0, 0.0, 0.0]
+    A = [
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+    ]
     A = reshape(A, 5, 5)
     A = convert(Array{Bool}, A)
     B = B = @inferred convexhull(A)
     C = CartesianIndex{}[]
-    push!(C, CartesianIndex{}(1,3))
-    push!(C, CartesianIndex{}(3,1))
-    push!(C, CartesianIndex{}(3,5))
-    push!(C, CartesianIndex{}(5,3))
-    @test typeof(B)==Array{CartesianIndex{2},1}
-    @test sort(B)==sort(C)
+    push!(C, CartesianIndex{}(1, 3))
+    push!(C, CartesianIndex{}(3, 1))
+    push!(C, CartesianIndex{}(3, 5))
+    push!(C, CartesianIndex{}(5, 3))
+    @test typeof(B) == Array{CartesianIndex{2},1}
+    @test sort(B) == sort(C)
 end

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,49 +1,61 @@
 @testset "label_components" begin
-    A = [true  true  false true;
-         true  false true  true]
-    lbltarget1 = [1 2 0 4;
-                  1 0 3 4]
+    A = [
+        true  true  false true
+        true  false true  true
+    ]
+    lbltarget1 = [
+        1 2 0 4
+        1 0 3 4
+    ]
     @test label_components(A, [1]) == lbltarget1
 end
 
 @testset "Erode / dilate" begin
-    A = zeros(4,4,3)
-    A[2,2,1] = 0.8
-    A[4,4,2] = 0.6
+    A = zeros(4, 4, 3)
+    A[2, 2, 1] = 0.8
+    A[4, 4, 2] = 0.6
     Ad = dilate(A, 1:2)
-    Ar = [0.8 0.8 0.8 0;
-          0.8 0.8 0.8 0;
-          0.8 0.8 0.8 0;
-          0 0 0 0]
-    Ag = [0 0 0 0;
-          0 0 0 0;
-          0 0 0.6 0.6;
-          0 0 0.6 0.6]
-    @test Ad == cat(Ar, Ag, zeros(4,4), dims=3)
+    Ar = [
+        0.8 0.8 0.8 0
+        0.8 0.8 0.8 0
+        0.8 0.8 0.8 0
+        0 0 0 0
+    ]
+    Ag = [
+        0 0 0 0
+        0 0 0 0
+        0 0 0.6 0.6
+        0 0 0.6 0.6
+    ]
+    @test Ad == cat(Ar, Ag, zeros(4, 4); dims=3)
     @test dilate!(copy(A), 1:2) == Ad
     Ae = erode(Ad, 1:2)
-    Ar = [0.8 0.8 0 0;
-          0.8 0.8 0 0;
-          0 0 0 0;
-          0 0 0 0]
-    Ag = [0 0 0 0;
-          0 0 0 0;
-          0 0 0 0;
-          0 0 0 0.6]
-    @test Ae == cat(Ar, Ag, zeros(4,4), dims=3)
+    Ar = [
+        0.8 0.8 0 0
+        0.8 0.8 0 0
+        0 0 0 0
+        0 0 0 0
+    ]
+    Ag = [
+        0 0 0 0
+        0 0 0 0
+        0 0 0 0
+        0 0 0 0.6
+    ]
+    @test Ae == cat(Ar, Ag, zeros(4, 4); dims=3)
     @test erode!(copy(Ad), 1:2) == Ae
 end
 
 @testset "Opening / closing" begin
-    A = zeros(4,4,3)
-    A[2,2,1] = 0.8
-    A[4,4,2] = 0.6
+    A = zeros(4, 4, 3)
+    A[2, 2, 1] = 0.8
+    A[4, 4, 2] = 0.6
     Ao = opening(A)
     @test opening(A, 1:3) == Ao
     @test opening!(copy(A), 1:3) == Ao
-    A = zeros(10,10)
-    A[4:7,4:7] .= 1
-    A[5,5] = 0
+    A = zeros(10, 10)
+    A[4:7, 4:7] .= 1
+    A[5, 5] = 0
     Ac = closing(A)
     @test closing(A, 1:3) == Ac
     @test closing!(copy(A), 1:3) == Ac
@@ -82,28 +94,28 @@ end
 @testset "Feature transform/Anisotropic images" begin
     function ind2cart(F)
         s = CartesianIndices(axes(F))
-        map(i->CartesianIndex(s[i]), F)
+        return map(i -> CartesianIndex(s[i]), F)
     end
 
-    A, w = [false false; false true], (3,1)
+    A, w = [false false; false true], (3, 1)
     F = feature_transform(A, w)
     @test F == ind2cart([4 4; 4 4])
     D = distance_transform(F, w)
     @test D ≈ [sqrt(10) 3.0; 1.0 0.0]
 
-    A, w = [false false; false true], (1,3)
+    A, w = [false false; false true], (1, 3)
     F = feature_transform(A, w)
     @test F == ind2cart([4 4; 4 4])
     D = distance_transform(F, w)
     @test D ≈ [sqrt(10) 1.0; 3.0 0.0]
 
-    A, w = [true false; false true], (3,1)
+    A, w = [true false; false true], (3, 1)
     F = feature_transform(A, w)
     @test F == ind2cart([1 1; 4 4])
     D = distance_transform(F, w)
     @test D == [0 1; 1 0]
 
-    A, w = [true false; false true], (1,3)
+    A, w = [true false; false true], (1, 3)
     F = feature_transform(A, w)
     @test F == ind2cart([1 4; 1 4])
     D = distance_transform(F, w)

--- a/test/dilation_and_erosion.jl
+++ b/test/dilation_and_erosion.jl
@@ -1,103 +1,111 @@
 @testset "Erode / dilate" begin
-        A = zeros(4,4,3)
-        A[2,2,1] = 0.8
-        A[4,4,2] = 0.6
-        Ae = erode(A)
-        @test Ae == zeros(size(A))
-        Ad = dilate(A, dims=1:2)
-        Ar = [0.8 0.8 0.8 0;
-              0.8 0.8 0.8 0;
-              0.8 0.8 0.8 0;
-              0 0 0 0]
-        Ag = [0 0 0 0;
-              0 0 0 0;
-              0 0 0.6 0.6;
-              0 0 0.6 0.6]
-        @test Ad == cat(Ar, Ag, zeros(4,4), dims=3)
-        @test dilate!(copy(A), dims=1:2) == Ad
-        Ae = erode(Ad, dims=1:2)
-        Ar = [0.8 0.8 0 0;
-              0.8 0.8 0 0;
-              0 0 0 0;
-              0 0 0 0]
-        Ag = [0 0 0 0;
-              0 0 0 0;
-              0 0 0 0;
-              0 0 0 0.6]
-        @test Ae == cat(Ar, Ag, zeros(4,4), dims=3)
-        @test erode!(copy(Ad), dims=1:2) == Ae
-        # issue Images.jl #311
-        @test dilate(trues(3)) == trues(3)
-        # ImageMeta
-        @test arraydata(dilate(ImageMeta(A))) == dilate(A)
-        @test arraydata(dilate(ImageMeta(A), dims=1:2)) == dilate(A, dims=1:2)
-        @test arraydata(erode(ImageMeta(A))) == erode(A)
-        @test arraydata(erode(ImageMeta(A), dims=1:2)) == erode(A, dims=1:2)
-    end
+    A = zeros(4, 4, 3)
+    A[2, 2, 1] = 0.8
+    A[4, 4, 2] = 0.6
+    Ae = erode(A)
+    @test Ae == zeros(size(A))
+    Ad = dilate(A; dims=1:2)
+    Ar = [
+        0.8 0.8 0.8 0
+        0.8 0.8 0.8 0
+        0.8 0.8 0.8 0
+        0 0 0 0
+    ]
+    Ag = [
+        0 0 0 0
+        0 0 0 0
+        0 0 0.6 0.6
+        0 0 0.6 0.6
+    ]
+    @test Ad == cat(Ar, Ag, zeros(4, 4); dims=3)
+    @test dilate!(copy(A); dims=1:2) == Ad
+    Ae = erode(Ad; dims=1:2)
+    Ar = [
+        0.8 0.8 0 0
+        0.8 0.8 0 0
+        0 0 0 0
+        0 0 0 0
+    ]
+    Ag = [
+        0 0 0 0
+        0 0 0 0
+        0 0 0 0
+        0 0 0 0.6
+    ]
+    @test Ae == cat(Ar, Ag, zeros(4, 4); dims=3)
+    @test erode!(copy(Ad); dims=1:2) == Ae
+    # issue Images.jl #311
+    @test dilate(trues(3)) == trues(3)
+    # ImageMeta
+    @test arraydata(dilate(ImageMeta(A))) == dilate(A)
+    @test arraydata(dilate(ImageMeta(A); dims=1:2)) == dilate(A; dims=1:2)
+    @test arraydata(erode(ImageMeta(A))) == erode(A)
+    @test arraydata(erode(ImageMeta(A); dims=1:2)) == erode(A; dims=1:2)
+end
 
-    @testset "Opening / closing" begin
-        A = zeros(4,4,3)
-        A[2,2,1] = 0.8
-        A[4,4,2] = 0.6
-        Ao = opening(A)
-        @test Ao == zeros(size(A))
-        @test opening(A, dims=1:3) == Ao
-        @test opening!(copy(A), dims=1:3) == Ao
-        A = zeros(10,10)
-        A[4:7,4:7] .= 1
-        B = copy(A)
-        A[5,5] = 0
-        Ac = closing(A)
-        @test Ac == B
-        @test closing(A, dims=1:3) == Ac
-        @test closing!(copy(A), dims=1:3) == Ac
-    end
+@testset "Opening / closing" begin
+    A = zeros(4, 4, 3)
+    A[2, 2, 1] = 0.8
+    A[4, 4, 2] = 0.6
+    Ao = opening(A)
+    @test Ao == zeros(size(A))
+    @test opening(A; dims=1:3) == Ao
+    @test opening!(copy(A); dims=1:3) == Ao
+    A = zeros(10, 10)
+    A[4:7, 4:7] .= 1
+    B = copy(A)
+    A[5, 5] = 0
+    Ac = closing(A)
+    @test Ac == B
+    @test closing(A; dims=1:3) == Ac
+    @test closing!(copy(A); dims=1:3) == Ac
+end
 
-    @testset "Morphological Top-hat" begin
-        A = zeros(13, 13)
-        A[2:3, 2:3] .= 1
-        Ae = copy(A)
-        A[5:9, 5:9] .= 1
-        Ao = tophat(A)
-        @test Ao == Ae
-        @test tophat(A, dims=1:2) == Ae
-        Aoo = tophat(Ae)
-        @test Aoo == Ae
-    end
+@testset "Morphological Top-hat" begin
+    A = zeros(13, 13)
+    A[2:3, 2:3] .= 1
+    Ae = copy(A)
+    A[5:9, 5:9] .= 1
+    Ao = tophat(A)
+    @test Ao == Ae
+    @test tophat(A; dims=1:2) == Ae
+    Aoo = tophat(Ae)
+    @test Aoo == Ae
+end
 
-    @testset "Morphological Bottom-hat" begin
-        A = ones(13, 13)
-        A[2:3, 2:3] .= 0
-        Ae = 1 .- copy(A)
-        A[5:9, 5:9] .= 0
-        Ao = bothat(A)
-        @test Ao == Ae
-        @test bothat(A, dims=1:2) == Ao
-    end
+@testset "Morphological Bottom-hat" begin
+    A = ones(13, 13)
+    A[2:3, 2:3] .= 0
+    Ae = 1 .- copy(A)
+    A[5:9, 5:9] .= 0
+    Ao = bothat(A)
+    @test Ao == Ae
+    @test bothat(A; dims=1:2) == Ao
+end
 
-    @testset "Morphological Gradient" begin
-        A = zeros(13, 13)
-        A[5:9, 5:9] .= 1
-        Ao = morphogradient(A)
-        @test morphogradient(A, dims=1:2) == morphogradient(A)
-        Ae = zeros(13, 13)
-        Ae[4:10, 4:10] .= 1
-        Ae[6:8, 6:8] .= 0
-        @test Ao == Ae
-        Aee = dilate(A) - erode(A)
-        @test Aee == Ae
-    end
+@testset "Morphological Gradient" begin
+    A = zeros(13, 13)
+    A[5:9, 5:9] .= 1
+    Ao = morphogradient(A)
+    @test morphogradient(A; dims=1:2) == morphogradient(A)
+    Ae = zeros(13, 13)
+    Ae[4:10, 4:10] .= 1
+    Ae[6:8, 6:8] .= 0
+    @test Ao == Ae
+    Aee = dilate(A) - erode(A)
+    @test Aee == Ae
+end
 
-    @testset "Morphological Laplacian" begin
-        A = zeros(13, 13)
-        A[5:9, 5:9] .= 1
-        Ao = morpholaplace(A)
-        @test morpholaplace(A, dims=1:2) == Ao
-        Ae = zeros(13, 13)
-        Ae[4:10, 4:10] .= 1
-        Ae[5:9, 5:9] .= -1
-        Ae[6:8, 6:8] .= 0
-        @test Ao == Ae
-        Aee = dilate(A) + erode(A) - 2A
-        @test Aee == Ae
-    end
+@testset "Morphological Laplacian" begin
+    A = zeros(13, 13)
+    A[5:9, 5:9] .= 1
+    Ao = morpholaplace(A)
+    @test morpholaplace(A; dims=1:2) == Ao
+    Ae = zeros(13, 13)
+    Ae[4:10, 4:10] .= 1
+    Ae[5:9, 5:9] .= -1
+    Ae[6:8, 6:8] .= 0
+    @test Ao == Ae
+    Aee = dilate(A) + erode(A) - 2A
+    @test Aee == Ae
+end

--- a/test/feature_transform.jl
+++ b/test/feature_transform.jl
@@ -1,7 +1,7 @@
 @testset "feature_transform" begin
     function ind2cart(F)
         s = CartesianIndices(axes(F))
-        map(i->CartesianIndex(s[i]), F)
+        return map(i -> CartesianIndex(s[i]), F)
     end
     @testset "Square Images" begin
         # (1)
@@ -40,7 +40,12 @@
         @test D == [1 1 0; 0 0 1; 0 0 0]
 
         # (6)
-        A = [true false true true; false true false false; false true true false; true false false false]
+        A = [
+            true false true true
+            false true false false
+            false true true false
+            true false false false
+        ]
         F = feature_transform(A)
         @test F == ind2cart([1 1 9 13; 1 6 6 13; 4 7 11 11; 4 4 11 11])
         D = distance_transform(F)
@@ -63,7 +68,13 @@
         @test D == [0 1; 1 1; 1 0]
 
         # (3)
-        A = [true false false; true false false; false true true; true true true; false true false]
+        A = [
+            true false false
+            true false false
+            false true true
+            true true true
+            false true false
+        ]
         F = feature_transform(A)
         @test F == ind2cart([1 1 1; 2 2 13; 2 8 13; 4 9 14; 4 10 10])
         D = distance_transform(F)
@@ -74,7 +85,7 @@
 
     @testset "Corner Case Images" begin
         null1 = CartesianIndex((typemin(Int),))
-        null2 = CartesianIndex((typemin(Int),typemin(Int)))
+        null2 = CartesianIndex((typemin(Int), typemin(Int)))
         # (1)
         A = [false]
         F = feature_transform(A)
@@ -118,46 +129,46 @@
         @test D == [0; 0; 1]
 
         # (7)
-        A = falses(3,3)
+        A = falses(3, 3)
         F = feature_transform(A)
-        @test all(x->x==null2, F)
+        @test all(x -> x == null2, F)
         D = distance_transform(F)
-        @test all(x->x==Inf, D)
+        @test all(x -> x == Inf, D)
 
         # (8)
-        A = trues(4,2,3)
+        A = trues(4, 2, 3)
         F = feature_transform(A)
         @test F == ind2cart(reshape(1:length(A), size(A)))
         D = distance_transform(F)
-        @test all(x->x==0, D)
+        @test all(x -> x == 0, D)
 
         # (9)
-        A = falses(4,2,3)
-        A[3,1,2] = true
-        @test all(==(CartesianIndex(3,1,2)), feature_transform(A))
+        A = falses(4, 2, 3)
+        A[3, 1, 2] = true
+        @test all(==(CartesianIndex(3, 1, 2)), feature_transform(A))
     end
 
     @testset "Anisotropic images" begin
-        A, w = [false false; false true], (3,1)
-        F = feature_transform(A, weights=w)
+        A, w = [false false; false true], (3, 1)
+        F = feature_transform(A; weights=w)
         @test F == ind2cart([4 4; 4 4])
         D = distance_transform(F, w)
         @test D ≈ [sqrt(10) 3.0; 1.0 0.0]
 
-        A, w = [false false; false true], (1,3)
-        F = feature_transform(A, weights=w)
+        A, w = [false false; false true], (1, 3)
+        F = feature_transform(A; weights=w)
         @test F == ind2cart([4 4; 4 4])
         D = distance_transform(F, w)
         @test D ≈ [sqrt(10) 1.0; 3.0 0.0]
 
-        A, w = [true false; false true], (3,1)
-        F = feature_transform(A, weights=w)
+        A, w = [true false; false true], (3, 1)
+        F = feature_transform(A; weights=w)
         @test F == ind2cart([1 1; 4 4])
         D = distance_transform(F, w)
         @test D == [0 1; 1 0]
 
-        A, w = [true false; false true], (1,3)
-        F = feature_transform(A, weights=w)
+        A, w = [true false; false true], (1, 3)
+        F = feature_transform(A; weights=w)
         @test F == ind2cart([1 4; 1 4])
         D = distance_transform(F, w)
         @test D == [0 1; 1 0]

--- a/test/imfill.jl
+++ b/test/imfill.jl
@@ -1,45 +1,48 @@
 @testset "imfill" begin
     #2 Dimensional case
-    image = Bool.([0 0 0 0 0 0 1 0 0 0
-         	   0 1 1 1 1 1 0 0 0 0
-         	   0 1 0 0 1 1 0 0 0 0
-         	   0 1 1 1 0 1 0 0 0 0
-         	   0 1 1 1 1 1 0 0 0 0
-         	   0 0 0 0 0 0 0 1 1 1
-         	   0 0 0 0 0 0 0 1 0 1
-         	   0 0 0 0 0 0 0 1 1 1
-	       	   0 0 0 0 0 0 0 0 0 0
-	           0 0 0 0 0 0 0 0 0 0])
-    answer = Bool.([0 0 0 0 0 0 1 0 0 0
-         	    0 1 1 1 1 1 0 0 0 0
-         	    0 1 1 1 1 1 0 0 0 0
-         	    0 1 1 1 1 1 0 0 0 0
-         	    0 1 1 1 1 1 0 0 0 0
-         	    0 0 0 0 0 0 0 1 1 1
-         	    0 0 0 0 0 0 0 1 1 1
-         	    0 0 0 0 0 0 0 1 1 1
-		    0 0 0 0 0 0 0 0 0 0
-	            0 0 0 0 0 0 0 0 0 0])
-	@test imfill(.!image, (0,2)) == (.!answer)
-	
-	#3 Dimensional case
-	A = zeros(Bool,3,size(image)[1],size(image)[2])
-	A[1,:,:] = image
-	A[2,:,:] = image
-	A[3,:,:] = image
-	B = zeros(Bool,3,size(answer)[1],size(answer)[2])
-	B[1,:,:] = answer
-	B[2,:,:] = answer
-	B[3,:,:] = answer
-	@test imfill(.!A, (0,8)) == (.!B)
-	
-	# Complete white image and complete black image case
-	img = zeros(Bool,10,10)
-	@test imfill(img,(0,10)) == img
-	@test imfill(.!img,(0,99)) == .!img
-	# Miscellaneous case
-	img[5,5] = true
-	@test imfill(.!img,(0,10)) == .!img
-	@test imfill(.!img,(0,99)) == zeros(Bool,10,10)	
-end
+    image = Bool[
+        0 0 0 0 0 0 1 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 1 0 0 1 1 0 0 0 0
+        0 1 1 1 0 1 0 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 0 0 0 0 0 0 1 1 1
+        0 0 0 0 0 0 0 1 0 1
+        0 0 0 0 0 0 0 1 1 1
+        0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0
+    ]
+    answer = Bool[
+        0 0 0 0 0 0 1 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 1 1 1 1 1 0 0 0 0
+        0 0 0 0 0 0 0 1 1 1
+        0 0 0 0 0 0 0 1 1 1
+        0 0 0 0 0 0 0 1 1 1
+        0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0
+    ]
+    @test imfill(.!image, (0, 2)) == (.!answer)
 
+    #3 Dimensional case
+    A = zeros(Bool, 3, size(image)[1], size(image)[2])
+    A[1, :, :] = image
+    A[2, :, :] = image
+    A[3, :, :] = image
+    B = zeros(Bool, 3, size(answer)[1], size(answer)[2])
+    B[1, :, :] = answer
+    B[2, :, :] = answer
+    B[3, :, :] = answer
+    @test imfill(.!A, (0, 8)) == (.!B)
+
+    # Complete white image and complete black image case
+    img = zeros(Bool, 10, 10)
+    @test imfill(img, (0, 10)) == img
+    @test imfill(.!img, (0, 99)) == .!img
+    # Miscellaneous case
+    img[5, 5] = true
+    @test imfill(.!img, (0, 10)) == .!img
+    @test imfill(.!img, (0, 99)) == zeros(Bool, 10, 10)
+end

--- a/test/isboundary.jl
+++ b/test/isboundary.jl
@@ -1,9 +1,13 @@
 import ImageMorphology: isboundary_thick, isboundary_dilate_erode
 
 @testset "isboundary" begin
-    A = zeros(Int, 16, 16); A[4:8, 4:8] .= 5; A[4:8, 9:12] .= 6; A[10:12,13:15] .= 3; A[10:12,3:6] .= 9;
+    A = zeros(Int, 16, 16)
+    A[4:8, 4:8] .= 5
+    A[4:8, 9:12] .= 6
+    A[10:12, 13:15] .= 3
+    A[10:12, 3:6] .= 9
     OA = OffsetArray(A, -1, -1)
-    FA = Float32.(A./2)
+    FA = Float32.(A ./ 2)
     B = A .!= 0
     OB = OffsetArray(B, -1, -1)
     GB = Gray{Bool}.(B)
@@ -11,93 +15,100 @@ import ImageMorphology: isboundary_thick, isboundary_dilate_erode
     C = copy(A)
     C[A .== 0] .= 1
     normC = C ./ maximum(C)
-    FC = Float32.(C./2)
+    FC = Float32.(C ./ 2)
     @test sum(isboundary(A)) == 48
     @test sum(isboundary(OA)) == 48
     @test sum(isboundary(FA)) === 48.0f0
     @test sum(isboundary(Gray{Float32}.(normA))) == 48
     @test sum(isboundary(RGB{N0f8}.(normA))) .== RGB{Float64}(48, 48, 48)
-    @test sum(isboundary(A; dims = 1)) == 32
-    @test sum(isboundary(A; dims = 2)) == 32
+    @test sum(isboundary(A; dims=1)) == 32
+    @test sum(isboundary(A; dims=2)) == 32
     @test sum(isboundary(GB)) == 42
     @test sum(isboundary(B)) == 42
     @test sum(isboundary(OB)) == 42
-    @test sum(isboundary(B; dims = 1)) == 32
-    @test sum(isboundary(B; dims = 2)) == 22
+    @test sum(isboundary(B; dims=1)) == 32
+    @test sum(isboundary(B; dims=2)) == 22
     @test sum(isboundary(C)) == 107
-    @test sum(isboundary(C, background = 1)) == 48
+    @test sum(isboundary(C; background=1)) == 48
     @test sum(isboundary(FC)) === 107.0f0
-    @test sum(isboundary(FC, background = 1/2)) === 48.0f0
-    @test sum(isboundary(Gray{Float32}.(normC), background = 0)) == 107
-    @test sum(isboundary(Gray{Float32}.(normC), background = Gray{Float32}(1/9))) == 48
-    @test sum(isboundary(RGB{N0f8}.(normC), background = RGB{N0f8}(1/9))) .== RGB{Float64}(48, 48, 48)
+    @test sum(isboundary(FC; background=1 / 2)) === 48.0f0
+    @test sum(isboundary(Gray{Float32}.(normC); background=0)) == 107
+    @test sum(isboundary(Gray{Float32}.(normC); background=Gray{Float32}(1 / 9))) == 48
+    @test sum(isboundary(RGB{N0f8}.(normC); background=RGB{N0f8}(1 / 9))) .==
+        RGB{Float64}(48, 48, 48)
 
     # Tests from pull request #32
     # Normal Case 20x20 binary image
-    img = [ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-        ];
+    img = [
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    ]
     check_img = zeros(Int, size(img))
     check_img[3, 4:15] .= 1
     check_img[8, 4:15] .= 1
-    check_img[3:8,4] .= 1
-    check_img[3:8,15] .= 1
+    check_img[3:8, 4] .= 1
+    check_img[3:8, 15] .= 1
     @test check_img == isboundary(img)
 
     # background = 1
     check_img = zeros(Int, size(img))
     check_img[2, 3:16] .= 1
     check_img[9, 3:16] .= 1
-    check_img[2:9,3] .= 1
-    check_img[2:9,16] .= 1
-    @test check_img == isboundary(img; background = 1)
+    check_img[2:9, 3] .= 1
+    check_img[2:9, 16] .= 1
+    @test check_img == isboundary(img; background=1)
 end
 
 @testset "isboundary_thick" begin
-    A = zeros(Int, 16, 16); A[4:8, 4:8] .= 5; A[4:8, 9:12] .= 6; A[10:12,13:15] .= 3; A[10:12,3:6] .= 9;
+    A = zeros(Int, 16, 16)
+    A[4:8, 4:8] .= 5
+    A[4:8, 9:12] .= 6
+    A[10:12, 13:15] .= 3
+    A[10:12, 3:6] .= 9
     OA = OffsetArray(A, -1, -1)
-    FA = Float32.(A./2)
+    FA = Float32.(A ./ 2)
     B = A .!= 0
     OB = OffsetArray(B, -1, -1)
     GB = Gray{Bool}.(B)
     normA = A ./ maximum(A)
     C = copy(A)
     C[A .== 0] .= 1
-    FC = Float32.(C./2)
+    FC = Float32.(C ./ 2)
     @test sum(isboundary_thick(A)) == 107
     @test sum(isboundary_thick(OA)) == 107
     @test sum(isboundary_thick(FA)) == 107
     @test sum(isboundary_thick(Gray{Float32}.(normA))) == 107
     # MethodError: no method matching isless(::RGB{N0f8}, ::RGB{N0f8})
     @test_broken sum(isboundary_broken(RGB{N0f8}.(normA))) .== RGB{Float64}(107, 107, 107)
-    @test sum(isboundary_thick(A; dims = 1)) == 61
-    @test sum(isboundary_thick(A; dims = 2)) == 54
+    @test sum(isboundary_thick(A; dims=1)) == 61
+    @test sum(isboundary_thick(A; dims=2)) == 54
     @test sum(isboundary_thick(GB)) == 101
     @test sum(isboundary_thick(B)) == 101
     @test sum(isboundary_thick(OB)) == 101
-    @test sum(isboundary_thick(B; dims = 1)) == 61
-    @test sum(isboundary_thick(B; dims = 2)) == 44
+    @test sum(isboundary_thick(B; dims=1)) == 61
+    @test sum(isboundary_thick(B; dims=2)) == 44
     @test sum(isboundary_thick(C)) == 107
     @test sum(isboundary_thick(FC)) == 107
-    img = [ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-        ];
+    img = [
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    ]
     check_img = [
          0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
         0  0  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0  0  0  0
@@ -114,16 +125,20 @@ end
 end
 
 @testset "isboundary == isboundary_thick .& image" begin
-    A = zeros(Int, 16, 16); A[4:8, 4:8] .= 5; A[4:8, 9:12] .= 6; A[10:12,13:15] .= 3; A[10:12,3:6] .= 9;
+    A = zeros(Int, 16, 16)
+    A[4:8, 4:8] .= 5
+    A[4:8, 9:12] .= 6
+    A[10:12, 13:15] .= 3
+    A[10:12, 3:6] .= 9
     B = A .!= 0
     C = copy(A)
     C[A .== 0] .= 1
     @test isboundary(A) == isboundary_thick(A) .& (A .!= 0)
     @test isboundary(B) == isboundary_thick(B) .& B
-    @test isboundary(B, background=false) == isboundary_thick(B) .& B
-    @test isboundary(B, background=true) == isboundary_thick(B) .& .!B
-    @test isboundary(B, background=-1) == isboundary_thick(B)
+    @test isboundary(B; background=false) == isboundary_thick(B) .& B
+    @test isboundary(B; background=true) == isboundary_thick(B) .& .!B
+    @test isboundary(B; background=-1) == isboundary_thick(B)
     @test isboundary(C) == isboundary_thick(C)
-    @test isboundary(C, background = 1) == isboundary_thick(C) .& (C .!= 1)
+    @test isboundary(C; background=1) == isboundary_thick(C) .& (C .!= 1)
     @test isboundary(A) == isboundary_dilate_erode(A)
 end

--- a/test/maxtree.jl
+++ b/test/maxtree.jl
@@ -1,19 +1,30 @@
 @testset "connectivity neighborhoods" begin
     @test @inferred(ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{1}, 1)) ==
-          ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{1}, 2) ==
-          [CartesianIndex{1}(-1), CartesianIndex{1}(1)]
+        ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{1}, 2) ==
+        [CartesianIndex{1}(-1), CartesianIndex{1}(1)]
     conn2d_4 = ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{2}, 1)
-    @test conn2d_4 ==
-        [CartesianIndex{2}(0, -1), CartesianIndex{2}(-1, 0),
-         CartesianIndex{2}(1, 0), CartesianIndex{2}(0, 1)]
-    @test @inferred(ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{2}, 2)) ==
-          [CartesianIndex{2}(-1, -1), CartesianIndex{2}(0, -1), CartesianIndex{2}(1, -1),
-           CartesianIndex{2}(-1, 0), CartesianIndex{2}(1, 0),
-           CartesianIndex{2}(-1, 1), CartesianIndex{2}(0, 1), CartesianIndex{2}(1, 1)]
+    @test conn2d_4 == [
+        CartesianIndex{2}(0, -1),
+        CartesianIndex{2}(-1, 0),
+        CartesianIndex{2}(1, 0),
+        CartesianIndex{2}(0, 1),
+    ]
+    @test @inferred(ImageMorphology.neighbor_cartesian_offsets(CartesianIndex{2}, 2)) == [
+        CartesianIndex{2}(-1, -1),
+        CartesianIndex{2}(0, -1),
+        CartesianIndex{2}(1, -1),
+        CartesianIndex{2}(-1, 0),
+        CartesianIndex{2}(1, 0),
+        CartesianIndex{2}(-1, 1),
+        CartesianIndex{2}(0, 1),
+        CartesianIndex{2}(1, 1),
+    ]
     @test ImageMorphology.linear_offsets(conn2d_4, fill(0, (1, 1))) == [-1, -1, 1, 1]
     @test ImageMorphology.linear_offsets(conn2d_4, fill(0, (2, 2))) == [-2, -1, 1, 2]
-    @test @inferred(ImageMorphology.linear_offsets(conn2d_4, fill(0, (3, 3)))) == [-3, -1, 1, 3]
-    @test @inferred(ImageMorphology.linear_offsets(conn2d_4, fill(0, (7, 9)))) == [-7, -1, 1, 7]
+    @test @inferred(ImageMorphology.linear_offsets(conn2d_4, fill(0, (3, 3)))) ==
+        [-3, -1, 1, 3]
+    @test @inferred(ImageMorphology.linear_offsets(conn2d_4, fill(0, (7, 9)))) ==
+        [-7, -1, 1, 7]
 end
 
 const CI2 = CartesianIndex{2}
@@ -21,10 +32,12 @@ const CI2 = CartesianIndex{2}
 bbox2d(x1, y1, x2, y2) = (CI2(x1, y1), CI2(x2, y2))
 
 @testset "MaxTree construction" begin
-    A = [15 13 16;
-         11 12 10;
-         16 11 14]
-    mtree = MaxTree(A, connectivity=1, rev=false) # test kwargs defaults
+    A = [
+        15 13 16
+        11 12 10
+        16 11 14
+    ]
+    mtree = MaxTree(A; connectivity=1, rev=false) # test kwargs defaults
     @test mtree isa MaxTree{2}
     @test mtree == MaxTree(A) # test kwargs defaults
     @test isequal(mtree, MaxTree(A))
@@ -33,125 +46,147 @@ bbox2d(x1, y1, x2, y2) = (CI2(x1, y1), CI2(x2, y2))
     @test axes(mtree) == axes(A)
     @test length(mtree) == length(A)
     @test !mtree.rev
-    @test mtree.parentindices == [4 5 4;
-                                  8 2 8;
-                                  2 2 2]
+    @test mtree.parentindices == [
+        4 5 4
+        8 2 8
+        2 2 2
+    ]
     @test mtree.traverse == [8, 2, 6, 5, 4, 9, 1, 3, 7]
     @test areas(mtree) == [1 3 1; 8 4 9; 1 1 1]
-    @test diameters(mtree) ==[1 3 1; 3 3 3; 1 1 1]
-    @test boundingboxes(mtree) ==
-        [bbox2d(1, 1, 1, 1) bbox2d(1, 1, 1, 3) bbox2d(1, 3, 1, 3);
-         bbox2d(1, 1, 3, 3) bbox2d(1, 1, 2, 3) bbox2d(1, 1, 3, 3);
-         bbox2d(3, 1, 3, 1) bbox2d(3, 2, 3, 2) bbox2d(3, 3, 3, 3)]
+    @test diameters(mtree) == [1 3 1; 3 3 3; 1 1 1]
+    @test boundingboxes(mtree) == [
+        bbox2d(1, 1, 1, 1) bbox2d(1, 1, 1, 3) bbox2d(1, 3, 1, 3)
+        bbox2d(1, 1, 3, 3) bbox2d(1, 1, 2, 3) bbox2d(1, 1, 3, 3)
+        bbox2d(3, 1, 3, 1) bbox2d(3, 2, 3, 2) bbox2d(3, 3, 3, 3)
+    ]
 
     # test 8-neighborhood
-    mtree2 = MaxTree(A, connectivity=2)
+    mtree2 = MaxTree(A; connectivity=2)
     @test !mtree2.rev
     @test mtree2 != mtree
-    @test mtree2.parentindices == [4 5 4;
-                                   8 2 8;
-                                   5 2 5]
+    @test mtree2.parentindices == [
+        4 5 4
+        8 2 8
+        5 2 5
+    ]
     @test mtree2.traverse == [8, 2, 6, 5, 4, 9, 1, 3, 7]
     @test areas(mtree2) == [1 3 1; 8 6 9; 1 1 1]
     @test diameters(mtree2) == [1 3 1; 3 3 3; 1 1 1]
-    @test boundingboxes(mtree2) ==
-        [bbox2d(1, 1, 1, 1) bbox2d(1, 1, 1, 3) bbox2d(1, 3, 1, 3);
-         bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3);
-         bbox2d(3, 1, 3, 1) bbox2d(3, 2, 3, 2) bbox2d(3, 3, 3, 3)]
+    @test boundingboxes(mtree2) == [
+        bbox2d(1, 1, 1, 1) bbox2d(1, 1, 1, 3) bbox2d(1, 3, 1, 3)
+        bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3)
+        bbox2d(3, 1, 3, 1) bbox2d(3, 2, 3, 2) bbox2d(3, 3, 3, 3)
+    ]
 
     # test reverse (brightest to darkest) MaxTree
-    mtree_rev = MaxTree(A, rev=true)
+    mtree_rev = MaxTree(A; rev=true)
     @test mtree_rev.rev
-    A = [15 13 16;
-         11 12 10;
-         16 11 14]
-    @test mtree_rev.parentindices == [3 9 3;
-                                      5 4 5;
-                                      3 5 1]
+    A = [
+        15 13 16
+        11 12 10
+        16 11 14
+    ]
+    @test mtree_rev.parentindices == [
+        3 9 3
+        5 4 5
+        3 5 1
+    ]
     @test mtree_rev.traverse == [3, 7, 1, 9, 4, 5, 2, 6, 8]
     @test areas(mtree_rev) == [7 5 1; 1 4 1; 9 1 6]
     @test diameters(mtree_rev) == [3 3 1; 1 3 1; 3 1 3]
-    @test boundingboxes(mtree_rev) ==
-        [bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 3, 1, 3);
-         bbox2d(2, 1, 2, 1) bbox2d(2, 1, 3, 3) bbox2d(2, 3, 2, 3);
-         bbox2d(1, 1, 3, 3) bbox2d(3, 2, 3, 2) bbox2d(1, 1, 3, 3)]
+    @test boundingboxes(mtree_rev) == [
+        bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 3, 1, 3)
+        bbox2d(2, 1, 2, 1) bbox2d(2, 1, 3, 3) bbox2d(2, 3, 2, 3)
+        bbox2d(1, 1, 3, 3) bbox2d(3, 2, 3, 2) bbox2d(1, 1, 3, 3)
+    ]
 
     # test reverse 8-neighborhood MaxTree
-    mtree2_rev = MaxTree(A, rev=true, connectivity=2)
+    mtree2_rev = MaxTree(A; rev=true, connectivity=2)
     @test mtree2_rev.rev
-    @test mtree2_rev.parentindices == [3 9 3;
-                                       5 4 2;
-                                       3 2 1]
+    @test mtree2_rev.parentindices == [
+        3 9 3
+        5 4 2
+        3 2 1
+    ]
     @test mtree2_rev.traverse == [3, 7, 1, 9, 4, 5, 2, 6, 8]
     @test areas(mtree2_rev) == [7 5 1; 3 4 1; 9 1 6]
     @test diameters(mtree2_rev) == [3 3 1; 3 3 1; 3 1 3]
-    @test boundingboxes(mtree2_rev) ==
-        [bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 3, 1, 3)
-         bbox2d(2, 1, 3, 3) bbox2d(2, 1, 3, 3) bbox2d(2, 3, 2, 3)
-         bbox2d(1, 1, 3, 3) bbox2d(3, 2, 3, 2) bbox2d(1, 1, 3, 3)]
+    @test boundingboxes(mtree2_rev) == [
+        bbox2d(1, 1, 3, 3) bbox2d(1, 1, 3, 3) bbox2d(1, 3, 1, 3)
+        bbox2d(2, 1, 3, 3) bbox2d(2, 1, 3, 3) bbox2d(2, 3, 2, 3)
+        bbox2d(1, 1, 3, 3) bbox2d(3, 2, 3, 2) bbox2d(1, 1, 3, 3)
+    ]
 
     # degenerated cases
     A00 = fill(0, (0, 0))
-    mtree00 = MaxTree(A00, connectivity=1, rev=false)
+    mtree00 = MaxTree(A00; connectivity=1, rev=false)
     @test mtree00 isa MaxTree{2}
     @test areas(mtree00) == Matrix{Int}(undef, 0, 0)
 
     A11 = fill(0, (1, 1))
-    mtree11 = MaxTree(A11, connectivity=2, rev=false)
+    mtree11 = MaxTree(A11; connectivity=2, rev=false)
     @test mtree11 isa MaxTree{2}
     @test areas(mtree11) == fill(1, (1, 1))
 
     A101 = fill(0, (1, 0, 1))
-    mtree101 = MaxTree(A101, connectivity=2, rev=false)
+    mtree101 = MaxTree(A101; connectivity=2, rev=false)
     @test mtree101 isa MaxTree{3}
     @test diameters(mtree101) == Array{Int}(undef, 1, 0, 1)
 
     # test grayscale
-    @test MaxTree(Gray.(A./255)) isa MaxTree{2}
+    @test MaxTree(Gray.(A ./ 255)) isa MaxTree{2}
 
     # test offset arrays
     Am11 = OffsetArray(A, -1, -1)
-    am11_tree = MaxTree(Am11, connectivity=1, rev=false)
+    am11_tree = MaxTree(Am11; connectivity=1, rev=false)
     @test size(am11_tree) == size(Am11)
     @test am11_tree.parentindices == mtree.parentindices
 end
 
 @testset "local_minima/maxima()" begin
-    A = [15 13 16;
-         11 12 10;
-         16 11 14]
-    @test local_maxima(A) == [3 0 1;
-                              0 0 0;
-                              2 0 4]
+    A = [
+        15 13 16
+        11 12 10
+        16 11 14
+    ]
+    @test local_maxima(A) == [
+        3 0 1
+        0 0 0
+        2 0 4
+    ]
     B = similar(A, Float64)
     @test local_maxima!(B, A) === B
     @test B == float(local_maxima(A))
 
     @test_throws DimensionMismatch local_maxima!(fill(0, (2, 2)), A)
 
-    @test local_maxima(A, connectivity=2) == [3 0 1; 0 0 0; 2 0 4]
+    @test local_maxima(A; connectivity=2) == [3 0 1; 0 0 0; 2 0 4]
     atree = MaxTree(A)
-    atree_rev = MaxTree(A, rev=true)
+    atree_rev = MaxTree(A; rev=true)
     @test_throws MethodError local_maxima(A, atree, connectivity=2)
     @test_throws ArgumentError local_maxima(A, atree_rev)
 
     # test local_minima
-    @test local_minima(A) == [0 0 0;
-                              3 0 1;
-                              0 2 0]
-    @test local_minima(A, connectivity=2) == [0 0 0;
-                                              0 0 1;
-                                              0 0 0]
+    @test local_minima(A) == [
+        0 0 0
+        3 0 1
+        0 2 0
+    ]
+    @test local_minima(A; connectivity=2) == [
+        0 0 0
+        0 0 1
+        0 0 0
+    ]
     @test local_minima!(B, A) === B
     @test B == float(local_minima(A))
     @test_throws DimensionMismatch local_minima!(fill(0, (4, 2)), A)
 
-    @test local_minima(A, atree_rev, connectivity=2) == local_minima(A)
+    @test local_minima(A, atree_rev; connectivity=2) == local_minima(A)
     @test_throws ArgumentError local_minima(A, atree)
 
     # test grayscale
-    @test local_maxima(Gray.(A./255)) == [3 0 1; 0 0 0; 2 0 4]
-    @test local_minima(Gray.(A./255)) == [0 0 0; 3 0 1; 0 2 0]
+    @test local_maxima(Gray.(A ./ 255)) == [3 0 1; 0 0 0; 2 0 4]
+    @test local_minima(Gray.(A ./ 255)) == [0 0 0; 3 0 1; 0 2 0]
 
     # test offset arrays
     Am11 = OffsetArray(A, -1, -1)
@@ -162,51 +197,55 @@ end
 end
 
 @testset "area_opening/closing()" begin
-    A = [3 1 3 1 4 4;
-         1 3 1 1 3 3;
-         1 1 1 1 1 1;
-         1 4 4 1 1 2;
-         1 4 1 1 5 5;
-         1 1 1 2 5 2]
+    A = [
+        3 1 3 1 4 4
+        1 3 1 1 3 3
+        1 1 1 1 1 1
+        1 4 4 1 1 2
+        1 4 1 1 5 5
+        1 1 1 2 5 2
+    ]
     B = similar(A)
     @test B === area_opening!(B, A)
     @test_throws DimensionMismatch area_opening!(similar(A, (7, 6)), A)
     atree = MaxTree(A)
-    atree_rev = MaxTree(A, rev=true)
+    atree_rev = MaxTree(A; rev=true)
     atree_small = MaxTree(A[1:5, 2:6])
     @test B == area_opening(A, atree)
     @test_throws ArgumentError area_opening(A, atree_rev)
     @test_throws DimensionMismatch area_opening(A, atree_small)
-    @test area_opening(A, min_area=3) ==
-        [1 1 1 1 3 3;
-         1 1 1 1 3 3;
-         1 1 1 1 1 1;
-         1 4 4 1 1 2;
-         1 4 1 1 5 5;
-         1 1 1 2 5 2]
-    @test area_opening(A, min_area=1) == A
-    @test area_opening(A, min_area=5) ==
-        [1 1 1 1 1 1;
-         1 1 1 1 1 1;
-         1 1 1 1 1 1;
-         1 1 1 1 1 2;
-         1 1 1 1 2 2;
-         1 1 1 2 2 2]
-    @test area_opening(A, min_area=45) == fill(0, (6, 6)) # image less than min_area
+    @test area_opening(A; min_area=3) == [
+        1 1 1 1 3 3
+        1 1 1 1 3 3
+        1 1 1 1 1 1
+        1 4 4 1 1 2
+        1 4 1 1 5 5
+        1 1 1 2 5 2
+    ]
+    @test area_opening(A; min_area=1) == A
+    @test area_opening(A; min_area=5) == [
+        1 1 1 1 1 1
+        1 1 1 1 1 1
+        1 1 1 1 1 1
+        1 1 1 1 1 2
+        1 1 1 1 2 2
+        1 1 1 2 2 2
+    ]
+    @test area_opening(A; min_area=45) == fill(0, (6, 6)) # image less than min_area
 
     mA = .-A
     mB = similar(mA)
     @test mB === area_closing!(mB, mA)
     @test_throws DimensionMismatch area_closing!(similar(A, (7, 6)), A)
     matree = MaxTree(mA)
-    matree_rev = MaxTree(mA, rev=true)
+    matree_rev = MaxTree(mA; rev=true)
     @test mB == area_closing(mA, atree_rev)
     @test_throws ArgumentError area_closing(mA, matree)
-    @test area_closing(mA, min_area=3) == .-area_opening(A, min_area=3)
+    @test area_closing(mA; min_area=3) == .-area_opening(A; min_area=3)
 
     # test grayscale
-    @test area_opening(Gray.(A./255)) == area_opening(A)
-    @test area_closing(Gray.(A./255)) == area_closing(A)
+    @test area_opening(Gray.(A ./ 255)) == area_opening(A)
+    @test area_closing(Gray.(A ./ 255)) == area_closing(A)
 
     # test offset arrays
     Am11 = OffsetArray(A, -1, -1)
@@ -217,58 +256,63 @@ end
 end
 
 @testset "diameter_opening/closing()" begin
-    A = [3 1 3 1 3 4;
-         1 3 1 1 4 3;
-         1 1 4 1 1 3;
-         1 4 4 1 1 2;
-         1 4 1 1 1 2;
-         1 1 1 2 5 1]
+    A = [
+        3 1 3 1 3 4
+        1 3 1 1 4 3
+        1 1 4 1 1 3
+        1 4 4 1 1 2
+        1 4 1 1 1 2
+        1 1 1 2 5 1
+    ]
     B = similar(A)
     @test B === diameter_opening!(B, A)
     @test_throws DimensionMismatch diameter_opening!(similar(A, (7, 6)), A)
     atree = MaxTree(A)
-    atree_rev = MaxTree(A, rev=true)
+    atree_rev = MaxTree(A; rev=true)
     atree_small = MaxTree(A[1:5, 2:6])
     @test B == diameter_opening(A, atree)
     @test_throws ArgumentError diameter_opening(A, atree_rev)
     @test_throws DimensionMismatch diameter_opening(A, atree_small)
-    @test diameter_opening(A, min_diameter=3) ==
-        [1 1 1 1 3 3;
-         1 1 1 1 3 3;
-         1 1 4 1 1 3;
-         1 4 4 1 1 2;
-         1 4 1 1 1 2;
-         1 1 1 1 1 1]
-    @test diameter_opening(A, min_diameter=1) == A
-    @test diameter_opening(A, min_diameter=3, connectivity=2) ==
-        [3 1 3 1 3 3;
-         1 3 1 1 3 3;
-         1 1 4 1 1 3;
-         1 4 4 1 1 2;
-         1 4 1 1 1 2;
-         1 1 1 2 2 1]
-     @test diameter_opening(A, min_diameter=5, connectivity=2) ==
-        [3 1 3 1 2 2;
-         1 3 1 1 2 2;
-         1 1 3 1 1 2;
-         1 3 3 1 1 2;
-         1 3 1 1 1 2;
-         1 1 1 2 2 1]
-    @test diameter_opening(A, min_diameter=45) == fill(0, (6, 6)) # image less than min_diameter
+    @test diameter_opening(A; min_diameter=3) == [
+        1 1 1 1 3 3
+        1 1 1 1 3 3
+        1 1 4 1 1 3
+        1 4 4 1 1 2
+        1 4 1 1 1 2
+        1 1 1 1 1 1
+    ]
+    @test diameter_opening(A; min_diameter=1) == A
+    @test diameter_opening(A; min_diameter=3, connectivity=2) == [
+        3 1 3 1 3 3
+        1 3 1 1 3 3
+        1 1 4 1 1 3
+        1 4 4 1 1 2
+        1 4 1 1 1 2
+        1 1 1 2 2 1
+    ]
+    @test diameter_opening(A; min_diameter=5, connectivity=2) == [
+        3 1 3 1 2 2
+        1 3 1 1 2 2
+        1 1 3 1 1 2
+        1 3 3 1 1 2
+        1 3 1 1 1 2
+        1 1 1 2 2 1
+    ]
+    @test diameter_opening(A; min_diameter=45) == fill(0, (6, 6)) # image less than min_diameter
 
     mA = .-A
     mB = similar(mA)
     @test mB === diameter_closing!(mB, mA)
     @test_throws DimensionMismatch diameter_closing!(similar(A, (7, 6)), A)
     matree = MaxTree(mA)
-    matree_rev = MaxTree(mA, rev=true)
+    matree_rev = MaxTree(mA; rev=true)
     @test mB == diameter_closing(mA, atree_rev)
     @test_throws ArgumentError diameter_closing(mA, matree)
-    @test diameter_closing(mA, min_diameter=3) == .-diameter_opening(A, min_diameter=3)
+    @test diameter_closing(mA; min_diameter=3) == .-diameter_opening(A; min_diameter=3)
 
     # test grayscale
-    @test diameter_opening(Gray.(A./255)) == diameter_opening(A)
-    @test diameter_closing(Gray.(A./255)) == diameter_closing(A)
+    @test diameter_opening(Gray.(A ./ 255)) == diameter_opening(A)
+    @test diameter_closing(Gray.(A ./ 255)) == diameter_closing(A)
 
     # test offset arrays
     Am11 = OffsetArray(A, -1, -1)

--- a/test/multithreaded.jl
+++ b/test/multithreaded.jl
@@ -6,11 +6,15 @@ using Test
     @test Threads.nthreads() > 1
     @testset "feature_transform" begin
         img = rand(100, 128) .> 0.9
-        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1)
+        @test feature_transform(img; nthreads=Threads.nthreads()) ==
+            feature_transform(img; nthreads=1)
         # Since the threaded implementation handles two dimensions specially, we should check 0d and 1d
         img = reshape([true])
-        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1) == reshape([CartesianIndex()])
+        @test feature_transform(img; nthreads=Threads.nthreads()) ==
+            feature_transform(img; nthreads=1) ==
+            reshape([CartesianIndex()])
         img = rand(100) .> 0.9
-        @test feature_transform(img; nthreads=Threads.nthreads()) == feature_transform(img; nthreads=1)
+        @test feature_transform(img; nthreads=Threads.nthreads()) ==
+            feature_transform(img; nthreads=1)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Suppressor
 @test isempty(detect_ambiguities(ImageMorphology))
 
 using Documenter
-Base.VERSION >= v"1.6" && doctest(ImageMorphology, manual = false)
+Base.VERSION >= v"1.6" && doctest(ImageMorphology; manual=false)
 
 @testset "ImageMorphology" begin
     include("structuring_element.jl")

--- a/test/thinning.jl
+++ b/test/thinning.jl
@@ -1,44 +1,50 @@
 @testset "Thinning" begin
     # for □ like figure
-    img = falses(20,20)
-    for i=7:7+4, j=7:7+4
-        img[i,j] = img[j,i] = true
+    img = falses(20, 20)
+    for i in 7:(7 + 4), j in 7:(7 + 4)
+        img[i, j] = img[j, i] = true
     end
     thin = thinning(img)
     @test count(thin .== 1) == 1
-    @test thin[9,9] == 1
+    @test thin[9, 9] == 1
 
     # for + like figure
-    img = falses(20,20)
-    for i=8:8+5, j=4:13+4
-        img[i,j] = true
-        img[j,i] = true
+    img = falses(20, 20)
+    for i in 8:(8 + 5), j in 4:(13 + 4)
+        img[i, j] = true
+        img[j, i] = true
     end
     ans = falses(size(img))
-    ans[[111,131,151,171,191,192,193,194,195,211,231,251,271]] .= 1
+    ans[[111, 131, 151, 171, 191, 192, 193, 194, 195, 211, 231, 251, 271]] .= 1
     @test thinning(img) == ans
 
-    img = Bool.([1 1 1 1 1 1
-                 0 0 0 0 0 0
-                 1 1 1 1 1 1
-                 1 1 1 1 1 1
-                 0 0 1 1 0 0
-                 0 0 0 0 0 0])
-    ans = Bool.([1 1 1 1 1 1
-                 0 0 0 0 0 0
-                 0 0 0 0 0 0
-                 1 1 1 1 1 0
-                 0 0 0 0 0 0
-                 0 0 0 0 0 0])
+    img = Bool[
+        1 1 1 1 1 1
+        0 0 0 0 0 0
+        1 1 1 1 1 1
+        1 1 1 1 1 1
+        0 0 1 1 0 0
+        0 0 0 0 0 0
+    ]
+    ans = Bool[
+        1 1 1 1 1 1
+        0 0 0 0 0 0
+        0 0 0 0 0 0
+        1 1 1 1 1 0
+        0 0 0 0 0 0
+        0 0 0 0 0 0
+    ]
     @test thinning(img) == ans
 
     # already thinned
-    img = Bool.([0 0 0 0 0 0
-                 0 0 0 1 1 0
-                 0 0 1 0 0 0
-                 0 0 1 0 0 0
-                 0 0 0 1 0 0
-                 0 0 0 0 0 0
-                 0 0 0 0 0 0])
+    img = Bool[
+        0 0 0 0 0 0
+        0 0 0 1 1 0
+        0 0 1 0 0 0
+        0 0 1 0 0 0
+        0 0 0 1 0 0
+        0 0 0 0 0 0
+        0 0 0 0 0 0
+    ]
     @test thinning(img) == img
 end


### PR DESCRIPTION
The format configuration is chosen to fit our previous code style (if we had) closely. While there are a few exceptions due to looooong lines, most codes look comfortable to my eyes.

Ideally I should apply the formatter in a rebasing manner without polutting the git history.  Yes I know it; but I become lazy now so if you are tracing the history, feel free to blame me :)

@timholy does this look good to you? If so then after a few experiments we can make it to other JuliaImages repositories.