### PR TITLE
implement `extreme_filter`

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -19,18 +19,41 @@ const SUITE = BenchmarkGroup()
 
 SUITE["extreme_filter"] = BenchmarkGroup()
 let grp = SUITE["extreme_filter"]
-    for T in [tst_types..., Gray{Bool}, Int, Bool]
+    for T in [tst_types..., Int]
         grp[T] = BenchmarkGroup()
         for sz in tst_sizes
             tst_img = rand(T, sz, sz)
 
             grp[T]["$sz×$sz"] = BenchmarkGroup()
             se = strel_diamond((3, 3))
-            grp[T]["$sz×$sz"]["diamond_r1_fast"] = @benchmarkable extreme_filter(max, $tst_img, $se)
-            grp[T]["$sz×$sz"]["diamond_r1_generic"] = @benchmarkable extreme_filter(max, $tst_img, $(collect(se)))
+            grp[T]["$sz×$sz"]["r1_diamond"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            se = centered(collect(se))
+            grp[T]["$sz×$sz"]["r1_generic"] = @benchmarkable extreme_filter(max, $tst_img, $se)
             se = strel_diamond((11, 11))
-            grp[T]["$sz×$sz"]["diamond_r5_fast"] = @benchmarkable extreme_filter(max, $tst_img, $se)
-            grp[T]["$sz×$sz"]["diamond_r5_generic"] = @benchmarkable extreme_filter(max, $tst_img, $(collect(se)))
+            grp[T]["$sz×$sz"]["r5_diamond"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            se = centered(collect(se))
+            grp[T]["$sz×$sz"]["r5_generic"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+        end
+    end
+end
+let grp = SUITE["extreme_filter"]
+    T = Bool
+    grp[T] = BenchmarkGroup()
+    for sz in tst_sizes
+        grp[T]["$sz×$sz"] = BenchmarkGroup()
+        for (cname, cr) in [("worst", 0.95), ("best", 0.05), ("random", 0.5)]
+            tst_img = fill(zero(T), sz, sz)
+            tst_img[rand(sz, sz) .>= cr] .= true
+
+            se = strel_diamond((3, 3))
+            grp[T]["$sz×$sz"]["r1_diamond_$cname"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            se = centered(collect(se))
+            grp[T]["$sz×$sz"]["r1_bool_$cname"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+
+            se = strel_diamond((11, 11))
+            grp[T]["$sz×$sz"]["r5_diamond_$cname"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            se = centered(collect(se))
+            grp[T]["$sz×$sz"]["r5_bool_$cname"] = @benchmarkable extreme_filter(max, $tst_img, $se)
         end
     end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,6 +17,24 @@ tst_types = (Gray{N0f8}, Gray{Float32})
 
 const SUITE = BenchmarkGroup()
 
+SUITE["extreme_filter"] = BenchmarkGroup()
+let grp = SUITE["extreme_filter"]
+    for T in [tst_types..., Gray{Bool}, Int, Bool]
+        grp[T] = BenchmarkGroup()
+        for sz in tst_sizes
+            tst_img = rand(T, sz, sz)
+
+            grp[T]["$sz×$sz"] = BenchmarkGroup()
+            se = strel_diamond((3, 3))
+            grp[T]["$sz×$sz"]["diamond_r1_fast"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            grp[T]["$sz×$sz"]["diamond_r1_generic"] = @benchmarkable extreme_filter(max, $tst_img, $(collect(se)))
+            se = strel_diamond((11, 11))
+            grp[T]["$sz×$sz"]["diamond_r5_fast"] = @benchmarkable extreme_filter(max, $tst_img, $se)
+            grp[T]["$sz×$sz"]["diamond_r5_generic"] = @benchmarkable extreme_filter(max, $tst_img, $(collect(se)))
+        end
+    end
+end
+
 SUITE["dilatation_and_erosion"] = BenchmarkGroup()
 let grp = SUITE["dilatation_and_erosion"]
     grp["erode"] = BenchmarkGroup()

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -12,6 +12,7 @@ include("structuring_element.jl")
 include("convexhull.jl")
 include("connected.jl")
 include("clearborder.jl")
+include("extreme_filter.jl")
 include("dilation_and_erosion.jl")
 include("isboundary.jl")
 include("thinning.jl")
@@ -37,6 +38,8 @@ export
     dilate!,
     erode,
     erode!,
+    extreme_filter,
+    extreme_filter!,
     opening,
     closing,
     tophat,

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -241,7 +241,7 @@ function _extreme_filter_bool!(f, out, A::AbstractArray{Gray{Bool}}, Ω)
     return _extreme_filter_bool!(f, out, reinterpret(Bool, A), Ω)
 end
 _fast_select(::typeof(max)) = _maximum_fast
-_fast_select(::typeof(min)) = _maximum_fast
+_fast_select(::typeof(min)) = _minimum_fast
 Base.@propagate_inbounds function _maximum_fast(A::AbstractArray{Bool}, p, Ω)
     rst = A[p]
     for o in Ω

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -92,8 +92,17 @@ function extreme_filter!(f, out, A, Ω::AbstractArray=strel_diamond(A))
     _extreme_filter!(strel_type(Ω), f, out, A, Ω)
 end
 
-# TODO(johnnychen94): add optimization for min/max on Bool array where we can short-circuit the result
-function _extreme_filter!(::MorphologySE, f, out, A, Ω)
+_extreme_filter!(::MorphologySE, f, out, A, Ω) = _extreme_filter_generic!(f, out, A, Ω)
+_extreme_filter!(::SEDiamond, f, out, A, Ω) = _extreme_filter_diamond!(f, out, A, Ω)
+
+
+
+###
+# Implementation details
+###
+
+function _extreme_filter_generic!(f, out, A, Ω)
+    @debug "call the generic `extreme_filter` implementation" fname=_extreme_filter_generic!
     Ω = strel(CartesianIndex, Ω)
     δ = CartesianIndex(strel_size(Ω) .÷ 2)
 
@@ -125,7 +134,9 @@ function _extreme_filter!(::MorphologySE, f, out, A, Ω)
     return out
 end
 
-function _extreme_filter!(::SEDiamond, f, out, A, Ω::SEDiamondArray)
+# optimized implementation for SEDiamond -- a typical case of separable filter
+function _extreme_filter_diamond!(f, out, A, Ω::SEDiamondArray)
+    @debug "call the optimized `extreme_filter` implementation for SEDiamond SE" fname=_extreme_filter_diamond!
     rΩ = strel_size(Ω) .÷ 2
     r = maximum(rΩ)
 

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -1,5 +1,5 @@
 """
-    extreme_filter(f, A, [dims]) -> out
+    extreme_filter(f, A; [dims]) -> out
     extreme_filter(f, A, Ω) -> out
 
 Filter the array `A` using select function `f(x, y)` for each Ω-neighborhood. The name
@@ -34,7 +34,7 @@ julia> extreme_filter(max, M) # max-filter using 4 direct neighbors along both d
  7  8  5  9  7
  6  6  6  6  7
 
-julia> extreme_filter(max, M, (1, )) # max-filter along the first dimension (column)
+julia> extreme_filter(max, M; dims=(1, )) # max-filter along the first dimension (column)
 5×5 Matrix{$Int}:
  8  6  9  4  8
  8  8  9  9  8
@@ -76,8 +76,8 @@ true
 See also the in-place version [`extreme_filter!`](@ref). Another function in ImageFiltering
 package `ImageFiltering.mapwindow` provides similar functionality.
 """
-extreme_filter(f, A, dims::Dims) = extreme_filter(f, A, strel_diamond(A, dims))
-extreme_filter(f, A, Ω::AbstractArray=strel_diamond(A)) = extreme_filter!(f, similar(A), A, Ω)
+extreme_filter(f, A; dims::Dims=coords_spatial(A)) = extreme_filter(f, A, strel_diamond(A, dims))
+extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 
 """
     extreme_filter!(f, out, A, [dims])

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -1,0 +1,123 @@
+"""
+    extreme_filter(f, A, [dims]) -> out
+    extreme_filter(f, A, Ω) -> out
+
+Filter the array `A` using select function `f(x, y)` for each Ω-neighborhood. The name
+"extreme" comes from the fact that typical select function `f` choice is `min` and `max`.
+
+For each pixel `p` in `A`, the select function `f` is applied to its Ω-neighborhood
+iteratively in a `f(...(f(f(A[p], A[p+Ω[1]]), A[p+Ω[2]]), ...)` manner. For instance, in the
+1-dimensional case, `out[p] = f(f(A[p], A[p-1]), A[p+1])` for each `p` is the default
+behavior.
+
+The Ω-neighborhood is defined by the `dims` or `Ω` argument. The `dims` argument specifies
+the dimensions of the neighborhood that can be used to construct a diamond shape `Ω` using
+[`strel_diamond`](@ref). The `Ω` is also known as structuring element (SE), it can be either
+displacement offsets or bool array mask, please refer to [`strel`](@ref) for more details.
+
+```jldoctest; setup=:(using ImageMorphology)
+julia> M = [4 6 5 3 4; 8 6 9 4 8; 7 8 4 9 6; 6 2 2 1 7; 1 6 5 2 6]
+5×5 Matrix{$Int}:
+ 4  6  5  3  4
+ 8  6  9  4  8
+ 7  8  4  9  6
+ 6  2  2  1  7
+ 1  6  5  2  6
+
+julia> extreme_filter(max, M) # max-filter using 4 direct neighbors along both dimensions
+5×5 Matrix{$Int}:
+ 8  6  9  5  8
+ 8  9  9  9  8
+ 8  8  9  9  9
+ 7  8  5  9  7
+ 6  6  6  6  7
+
+julia> extreme_filter(max, M, (1, )) # max-filter along the first dimension (column)
+5×5 Matrix{$Int}:
+ 8  6  9  4  8
+ 8  8  9  9  8
+ 8  8  9  9  8
+ 7  8  5  9  7
+ 6  6  5  2  7
+```
+
+`Ω` can be either an `AbstractArray{Bool}` mask array with `true` element indicating
+connectivity, or a `AbstractArray{<:CartesianIndex}` array with each element indicating the
+displacement offset to its center element.
+
+```
+julia> Ω_mask = Bool[1 1 0; 1 1 0; 1 0 0] # custom neighborhood in mask format
+3×3 Matrix{Bool}:
+ 1  1  0
+ 1  1  0
+ 1  0  0
+
+julia> out = extreme_filter(max, M, Ω_mask)
+5×5 Matrix{$Int}:
+ 4  8  6  9  4
+ 8  8  9  9  9
+ 8  8  9  9  9
+ 7  8  8  9  9
+ 6  6  6  5  7
+
+julia> Ω_offsets = strel(CartesianIndex, Ω_mask) # custom neighborhood as displacement offset
+4-element Vector{CartesianIndex{2}}:
+ CartesianIndex(-1, -1)
+ CartesianIndex(0, -1)
+ CartesianIndex(1, -1)
+ CartesianIndex(-1, 0)
+
+julia> out == extreme_filter(max, M, Ω_offsets) # both versions work equivalently
+true
+```
+
+See also the in-place version [`extreme_filter!`](@ref). Another function in ImageFiltering
+package `ImageFiltering.mapwindow` provides similar functionality.
+"""
+extreme_filter(f, A, dims::Dims) = extreme_filter(f, A, strel_diamond(A, dims))
+extreme_filter(f, A, Ω::AbstractArray=strel_diamond(A)) = extreme_filter!(f, similar(A), A, Ω)
+
+"""
+    extreme_filter!(f, out, A, [dims])
+    extreme_filter!(f, out, A, Ω)
+
+The in-place version of [`extreme_filter`](@ref) where `out` is the output array that gets
+modified.
+"""
+extreme_filter!(f, out, A, dims::Dims) = extreme_filter!(f, out, A, strel_diamond(A, dims))
+function extreme_filter!(f, out, A, Ω::AbstractArray=strel_diamond(A))
+    _extreme_filter!(strel_type(Ω), f, out, A, Ω)
+end
+
+function _extreme_filter!(::MorphologySE, f, out, A, Ω)
+    axes(out) == axes(A) || throw(DimensionMismatch("axes(out) must match axes(A)"))
+
+    Ω = strel(CartesianIndex, Ω)
+    δ = CartesianIndex(strel_size(Ω) .÷ 2)
+
+    R = CartesianIndices(A)
+    R_inner = (first(R)+δ):(last(R)-δ)
+
+    # for interior points, boundary check is unnecessary
+    @inbounds for p in R_inner
+        out[p] = _select_region(f, A, p, Ω)
+    end
+    # for edge points, skip if the offset exceeds the boundary
+    @inbounds for p in EdgeIterator(R, R_inner)
+        Ωp = filter(o->in(p+o, R), Ω)
+        out[p] = _select_region(f, A, p, Ωp)
+    end
+    return out
+end
+
+# TODO(johnnychen94): add specialization on max/min for Bool array
+function _select_region(f, A, p, offsets)
+    # Carefully building `offsets` in the caller `_extreme_filter!` so that boundscheck can
+    # be skipped here
+    s = @inbounds A[p]
+    @inbounds for o in offsets
+        v = A[p+o]
+        s = f(s, v)
+    end
+    return s
+end

--- a/test/extreme_filter.jl
+++ b/test/extreme_filter.jl
@@ -1,0 +1,49 @@
+@testset "extreme_filter" begin
+    @testset "numerical" begin
+        # Bool
+        img = fill(false, 5, 5); img[3, 3] = 1
+        ref = collect(strel_diamond((5, 5); r=1))
+
+        img_d = @inferred extreme_filter(max, img)
+        @test img_d == ref
+        @test ref == .!extreme_filter(min, .!img) # dual property
+
+        # Int
+        A = Int[4 6 5 3 4; 8 6 9 4 8; 7 8 4 9 6; 6 2 2 1 7; 1 6 5 2 6]
+        ref = [8 6 9 5 8; 8 9 9 9 8; 8 8 9 9 9; 7 8 5 9 7; 6 6 6 6 7]
+        Ad = @inferred extreme_filter(max, A)
+        @test Ad == ref
+
+        # Gray{Float32}
+        img = Gray{Float32}.(A./9)
+        img_d = @inferred extreme_filter(max, img)
+        @test ref == gray.(img_d).*9
+    end
+
+    @testset "strel" begin
+        # ensure it supports both strel representations
+        A = rand(32, 32)
+        se_mask = centered(collect(strel_diamond(A)))
+        out = extreme_filter(max, A, se_mask)
+        se_offsets = strel(CartesianIndex, se)
+        @test out == extreme_filter(max, A, se_offsets)
+    end
+
+    @testset "diamond" begin
+        # ensure the optimized implementation work equivalently to the generic fallback implementation
+        for N in (1, 2, 3)
+            sz = ntuple(_->32, N)
+            img = rand(sz...)
+            for r in (1, 3)
+                dims_list = ntuple(i->ntuple(identity, i), N)
+                for dims in dims_list
+                    se = centered(collect(strel_diamond(img, dims)))
+                    ref = extreme_filter(max, img, se) # this hits the generic path
+
+                    out = extreme_filter(max, img; dims=dims) # this hits the optimized path
+                    @test out == ref
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ Base.VERSION >= v"1.6" && doctest(ImageMorphology; manual=false)
 
 @testset "ImageMorphology" begin
     include("structuring_element.jl")
+    include("extreme_filter.jl")
     include("convexhull.jl")
     include("connected.jl")
     include("dilation_and_erosion.jl")


### PR DESCRIPTION
This is a generalized version of `extremefilt!` that supports the general structuring element concept.

This commit also fixes #68 by introducing an extra array memory so that we don't mess up with the order.

```julia
using ImageMorphology
using BenchmarkTools

img = rand(512, 512)
out = copy(img)
@btime extreme_filter!(max, $out, $img);
# 256x256: 180.845 μs (11 allocations: 288 bytes)
# 512x512: 1.508 ms (11 allocations: 288 bytes)
@btime extremefilt!($out, max);
# 256x256: 263.021 μs (6 allocations: 96 bytes)
# 512x512: 1.466 ms (6 allocations: 96 bytes)

# general structuring element
se = strel_diamond(img) # type: SEDiamondArray
# the optimized version works equivalently to the generic version
extreme_filter(max, img, se) == extreme_filter(max, img, collect(se)) # true

@btime extreme_filter(max, img, se);
# 256x256: 205.250 μs (10 allocations: 512.17 KiB)
# 512x512: 1.371 ms (10 allocations: 2.00 MiB)
@btime extreme_filter(max, img, collect(se));
# 256x256: 358.339 μs (10 allocations: 512.59 KiB)
# 512x512: 1.457 ms (10 allocations: 2.00 MiB)
```

We might make it even faster, but that's the future work, though.

Tests are needed. Deprecations on `extremfilt!` will be handled in future PRs.