### PR TITLE
reexport centered and document it

### DIFF
--- a/docs/src/structuring_element.md
+++ b/docs/src/structuring_element.md
@@ -108,9 +108,27 @@ helper function. `strel` is the short name for "STRucturing ELement".
 To convert a connectivity mask representation to displacement offset representation:
 
 ```@example concept_se
-Ω_mask = Bool[1 1 1; 1 1 0; 0 0 0]
+Ω_mask = Bool[1 1 1; 1 1 0; 0 0 0] |> centered
 Ω_offsets = strel(CartesianIndex, Ω_mask)
 ```
+
+!!! note "zero-centered mask"
+    The mask array is expected to be zero-centered. That means, the axes of a 3×3 mask `axes(se)`
+    should be `(-1:1, -1:1)`. The `centered` function is used to shift the center point of the array
+    to `(0, 0, ..., 0)`.
+    ```julia
+    julia> A = centered([1 2 3; 4 5 6; 7 8 9])
+    3×3 OffsetArray(::Matrix{Int64}, -1:1, -1:1) with eltype Int64 with indices -1:1×-1:1:
+     1  2  3
+     4  5  6
+     7  8  9
+
+    julia> A[-1, -1], A[0, 0], A[1, 1] # top-left, center, bottom-right
+    (1, 5, 9)
+    ```
+    This `centered` function comes from [OffsetArrays.jl](https://github.com/JuliaArrays/OffsetArrays.jl)
+    and is also exported by ImageMorphology.
+
 
 And to convert back from a displacement offset representation to connectivity mask representation:
 

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -3,6 +3,7 @@ module ImageMorphology
 using ImageCore
 using ImageCore: GenericGrayImage
 using ImageCore.OffsetArrays
+using ImageCore.OffsetArrays: centered
 using LinearAlgebra
 using TiledIteration: EdgeIterator, SplitAxis, SplitAxes
 using Requires
@@ -24,6 +25,7 @@ include("deprecations.jl")
 
 export
     # structuring_element.jl
+    centered, # from OffsetArrays
     strel,
     strel_type,
     strel_size,

--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -1,4 +1,7 @@
 abstract type MorphologySE{N} end
+abstract type MorphologySEArray{N} <: AbstractArray{Bool,N} end
+
+OffsetArrays.centered(A::MorphologySEArray) = A
 
 """
     SEMask{N}()
@@ -153,7 +156,7 @@ end
 
 The instantiated array object of [`SEDiamond`](@ref ImageMorphology.SEDiamond).
 """
-struct SEDiamondArray{N,K,R<:AbstractUnitRange{Int},S} <: AbstractArray{Bool,N}
+struct SEDiamondArray{N,K,R<:AbstractUnitRange{Int},S} <: MorphologySEArray{N}
     axes::NTuple{N,R}
     dims::Dims{K}
     r::Int # radius
@@ -181,7 +184,7 @@ end
 
 The instantiated array object of [`SEBox`](@ref ImageMorphology.SEBox).
 """
-struct SEBoxArray{N,R<:AbstractUnitRange{Int}} <: AbstractArray{Bool,N}
+struct SEBoxArray{N,R<:AbstractUnitRange{Int}} <: MorphologySEArray{N}
     axes::NTuple{N,R}
     r::Dims{N}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using ImageMorphology
 using ImageCore
 using Test
 using OffsetArrays
-using OffsetArrays: centered
 using ImageMetadata
 using Suppressor
 

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -240,3 +240,10 @@ end
     se = [CartesianIndex(-2, -2), CartesianIndex(1, 1)]
     @test strel_size(se) == (5, 5)
 end
+
+@testset "centered" begin
+    se = strel_diamond((3, 3))
+    @test centered(se) === se
+    se = strel_box((3, 3))
+    @test centered(se) === se
+end


### PR DESCRIPTION
Users almost certainly need this function to build their own structuring element, thus I believe it's a good idea to export it.