### PR TITLE
change default diamond half-size to be maximum

### DIFF
--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -98,7 +98,7 @@ struct SEDiamond{N,K,R<:AbstractUnitRange{Int}} <: MorphologySE{N}
         return new{N,K,R}(axes, dims, r)
     end
 end
-function SEDiamond{N}(ax::NTuple{N,R}, dims=ntuple(identity, N); r=minimum(length.(ax)) ÷ 2) where {N,R}
+function SEDiamond{N}(ax::NTuple{N,R}, dims=ntuple(identity, N); r=maximum(length.(ax)) ÷ 2) where {N,R}
     return SEDiamond{N,length(dims),R}(ax, dims, r)
 end
 
@@ -339,7 +339,7 @@ _strel_array(se::SEBox) = SEBoxArray(se)
 Construct the N-dimensional structuring element (SE) for a diamond shape.
 
 If image `A` is provided, then `size=(3, 3, ...)` and `(1, 2, ..., N)` are the default
-values for `size` and `dims`. The diamond half-size `r::Int` will be `minimum(size)÷2` if
+values for `size` and `dims`. The diamond half-size `r::Int` will be `maximum(size)÷2` if
 not specified.
 
 ```jldoctest; setup=:(using ImageMorphology)
@@ -361,9 +361,9 @@ julia> se = strel_diamond((5,5))
 
 julia> se = strel_diamond(img, (1,)) # mask along dimension 1
 3×1 ImageMorphology.SEDiamondArray{2, 1, UnitRange{$Int}, 1} with indices -1:1×0:0:
- 0
  1
- 0
+ 1
+ 1
 
 julia> se = strel_diamond((3,3), (1,)) # 3×3 mask along dimension 1
 3×3 ImageMorphology.SEDiamondArray{2, 1, UnitRange{$Int}, 1} with indices -1:1×-1:1:
@@ -381,7 +381,8 @@ julia> se = strel_diamond((3,3), (1,)) # 3×3 mask along dimension 1
 See also [`strel`](@ref) and [`strel_box`](@ref).
 """
 function strel_diamond(img::AbstractArray{T,N}, dims=coords_spatial(img); kw...) where {T,N}
-    return strel_diamond(ntuple(i -> in(i, dims) ? 3 : 1, N), dims; kw...)
+    sz = ntuple(i -> in(i, dims) ? 3 : 1, N)
+    return strel_diamond(sz, dims; kw...)
 end
 function strel_diamond(sz::Dims{N}, dims::Dims=ntuple(identity, N); kw...) where {N}
     all(isodd, sz) || throw(ArgumentError("size should be odd integers"))

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -105,13 +105,13 @@ end
         @test se == centered(Bool[0 0 1 0 0; 0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0; 0 0 1 0 0])
 
         se = @inferred strel_diamond((3, 5))
-        @test se == centered(Bool[0 0 1 0 0; 0 1 1 1 0; 0 0 1 0 0])
+        @test se == centered(Bool[0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0])
 
         se = @inferred strel_diamond((3, 5), (1,))
         @test se == centered(Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0])
 
         se = @inferred strel_diamond((3, 5), (2,))
-        @test se == centered(Bool[0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0])
+        @test se == centered(Bool[0 0 0 0 0; 1 1 1 1 1; 0 0 0 0 0])
 
         se = @inferred strel_diamond((3, 5); r=2)
         @test se == centered(Bool[0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0])

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -99,7 +99,7 @@ end
         @test se == strel_diamond(img, (1, 2); r=1)
 
         se = @inferred strel_diamond(img, (1, ))
-        @test se == centered(reshape(Bool[0, 1, 0], (3, 1)))
+        @test se == centered(reshape(Bool[1, 1, 1], (3, 1)))
 
         se = @inferred strel_diamond((5, 5))
         @test se == centered(Bool[0 0 1 0 0; 0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0; 0 0 1 0 0])


### PR DESCRIPTION
For the convenient `strel_diamond(img, dims)` usage, we'd expect it to produce equivalent SE to `strel_diamond((3, 3), dims)`

The following is what we get on the master branch, I believe this isn't ideal and can cause confusion:

```julia
julia> strel_diamond(rand(64, 64), (1,))
3×1 ImageMorphology.SEDiamondArray{2, 1, UnitRange{Int64}, 1} with indices -1:1×0:0:
 0
 1
 0

julia> strel_diamond((3,3),(1,))
3×3 ImageMorphology.SEDiamondArray{2, 1, UnitRange{Int64}, 1} with indices -1:1×-1:1:
 0  1  0
 0  1  0
 0  1  0
```

This PR thus changes the default diamond half-size from `minimum(size) .÷ 2` to `maximum(size) .÷ 2`, which gives:

```julia
julia> strel_diamond(rand(64, 64), (1,))
3×1 ImageMorphology.SEDiamondArray{2, 1, UnitRange{Int64}, 1} with indices -1:1×0:0:
 1
 1
 1
```