### PR TITLE
strel_box and strel_diamond: support Int as dims

### DIFF
--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -381,10 +381,12 @@ julia> se = strel_diamond((3,3), (1,)) # 3×3 mask along dimension 1
 See also [`strel`](@ref) and [`strel_box`](@ref).
 """
 function strel_diamond(img::AbstractArray{T,N}, dims=coords_spatial(img); kw...) where {T,N}
+    dims = _to_dims(dims)
     sz = ntuple(i -> in(i, dims) ? 3 : 1, N)
     return strel_diamond(sz, dims; kw...)
 end
-function strel_diamond(sz::Dims{N}, dims::Dims=ntuple(identity, N); kw...) where {N}
+function strel_diamond(sz::Dims{N}, dims::Union{Int,Dims}=ntuple(identity, N); kw...) where {N}
+    dims = _to_dims(dims)
     all(isodd, sz) || throw(ArgumentError("size should be odd integers"))
     ax = map(r -> (-r):r, sz .÷ 2)
     return _strel_array(SEDiamond{N}(ax, dims; kw...))
@@ -424,18 +426,23 @@ julia> se = strel_box((5,5); r=(1,2))
 See also [`strel`](@ref) and [`strel_box`](@ref).
 """
 strel_box(A::AbstractArray; kw...) = strel_box(ntuple(i -> 3, ndims(A)); kw...)
-strel_box(A::AbstractArray, dims::Dims) = strel_box(ntuple(i -> 3, ndims(A)), dims)
+strel_box(A::AbstractArray, dims::Union{Int,Dims}) = strel_box(ntuple(i -> 3, ndims(A)), dims)
 function strel_box(sz::Dims{N}; kw...) where {N}
     all(isodd, sz) || throw(ArgumentError("size should be odd integers"))
     ax = map(r -> (-r):r, sz .÷ 2)
     return _strel_array(SEBox{N}(ax; kw...))
 end
-function strel_box(sz::Dims{N}, dims::Dims) where {N}
+function strel_box(sz::Dims{N}, dims::Union{Int,Dims}) where {N}
+    dims = _to_dims(dims)
     all(isodd, sz) || throw(ArgumentError("size should be odd integers"))
     radius = ntuple(i -> in(i, dims) ? sz[i] ÷ 2 : 0, N)
     ax = map(r -> (-r):r, radius)
     return _strel_array(SEBox{N}(ax; r=radius))
 end
+
+# Tuple(1) is not inferable
+@inline _to_dims(i::Int) = (i,)
+@inline _to_dims(dims::Dims) = dims
 
 # conversion between different SE arrays
 function strel(SET::MorphologySE, se::T) where {T}

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -34,7 +34,7 @@
     @testset "mask to offset" begin
         se = centered(Bool[1, 0, 1])
         se_offsets = @inferred strel(CartesianIndex, se)
-        @test se_offsets == [CartesianIndex(-1,), CartesianIndex(1,)]
+        @test se_offsets == [CartesianIndex(-1), CartesianIndex(1)]
         @test se_offsets == strel(CartesianIndex, centered(Bool[1, 1, 1]))
 
         se = centered(Bool[1 0 0; 0 1 0; 0 0 1])
@@ -74,7 +74,7 @@ end
 
 @testset "strel_diamond" begin
     @testset "N=1" begin
-        img = rand(5,)
+        img = rand(5)
         se = @inferred strel_diamond(img)
         @test se isa ImageMorphology.SEDiamondArray
         @test eltype(se) == Bool
@@ -98,7 +98,8 @@ end
         @test se == strel_diamond((3, 3), (1, 2); r=1)
         @test se == strel_diamond(img, (1, 2); r=1)
 
-        se = @inferred strel_diamond(img, (1, ))
+        se = @inferred strel_diamond(img, (1,))
+        @test se == @inferred strel_diamond(img, 1)
         @test se == centered(reshape(Bool[1, 1, 1], (3, 1)))
 
         se = @inferred strel_diamond((5, 5))
@@ -108,6 +109,7 @@ end
         @test se == centered(Bool[0 1 1 1 0; 1 1 1 1 1; 0 1 1 1 0])
 
         se = @inferred strel_diamond((3, 5), (1,))
+        @test se == @inferred strel_diamond((3, 5), 1)
         @test se == centered(Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0])
 
         se = @inferred strel_diamond((3, 5), (2,))
@@ -144,7 +146,7 @@ end
     # edge cases
     img = rand(5, 5)
     err = ArgumentError("`axes` length should be at least 2")
-    @test_throws err strel_diamond((3,), (1, 2,))
+    @test_throws err strel_diamond((3,), (1, 2))
     err = ArgumentError("size should be odd integers")
     @test_throws err strel_diamond((2, 3))
     err = ArgumentError("dims should be unique")
@@ -155,7 +157,7 @@ end
 
 @testset "strel_box" begin
     @testset "N=1" begin
-        img = rand(5,)
+        img = rand(5)
         se = @inferred strel_box(img)
         @test se isa ImageMorphology.SEBoxArray
         @test eltype(se) == Bool
@@ -176,20 +178,25 @@ end
         @test se == centered(Bool[1 1 1; 1 1 1; 1 1 1])
         @test se == strel_box(img; r=2)
 
+        se = @inferred strel_box(img, (1,))
+        @test se == @inferred strel_box((3, 3), (1,))
+        @test se == @inferred strel_box((3, 3), 1)
+
         se = @inferred strel_box((3, 5); r=1)
         @test se == centered(Bool[0 1 1 1 0; 0 1 1 1 0; 0 1 1 1 0])
 
         se = @inferred strel_box((3, 5); r=(1, 0))
         @test se == centered(Bool[0 0 1 0 0; 0 0 1 0 0; 0 0 1 0 0])
 
-        se = @inferred strel_box((3, 5), (1, ))
+        se = @inferred strel_box((3, 5), (1,))
+        @test se == @inferred strel_box((3, 5), 1)
         @test se == centered(reshape(Bool[1, 1, 1], 3, 1))
 
         se = @inferred strel_box((3, 5); r=(0, 1))
         @test se == centered(Bool[0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0])
 
-        se = @inferred strel_box((3, 5), (2, ))
-        @test se == centered(Bool[1 1 1 1 1; ])
+        se = @inferred strel_box((3, 5), (2,))
+        @test se == centered(Bool[1 1 1 1 1;])
 
         se = @inferred strel_box((3, 5); r=2)
         @test se == centered(Bool[1 1 1 1 1; 1 1 1 1 1; 1 1 1 1 1])
@@ -211,7 +218,7 @@ end
     @testset "strel conversion" begin
         se = strel_box((3, 3))
         se_offsets = @inferred strel(CartesianIndex, se)
-        @test se_offsets == filter(i->!iszero(i), vec(CartesianIndices((-1:1, -1:1))))
+        @test se_offsets == filter(i -> !iszero(i), vec(CartesianIndices((-1:1, -1:1))))
         se_mask = @inferred strel(Bool, se)
         # not BitMatrix as SEBoxArray provides more information of what the SE is
         @test se_mask isa ImageMorphology.SEBoxArray
@@ -231,10 +238,10 @@ end
 end
 
 @testset "strel_size" begin
-    se = strel_diamond((5, 5), (1, ))
+    se = strel_diamond((5, 5), (1,))
     @test strel_size(se) == strel_size(centered(collect(se))) == (5, 1)
 
-    se = strel_box((5, 5), (2, ))
+    se = strel_box((5, 5), (2,))
     @test strel_size(se) == strel_size(centered(collect(se))) == (1, 5)
 
     se = [CartesianIndex(-2, -2), CartesianIndex(1, 1)]


### PR DESCRIPTION
This allows the int type `dims` in, e.g., `dilate(img; dims=1)`, to be passed to `strel_box` and `strel_diamond`.

A relatively safe and small change, so I'll merge quickly.