### PR TITLE
set default extreme_filter se to box

### DIFF
--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -13,13 +13,13 @@ iteratively in a `f(...(f(f(A[p], A[p+Ω[1]]), A[p+Ω[2]]), ...)` manner. For in
 behavior.
 
 The Ω-neighborhood is defined by the `dims` or `Ω` argument. The `dims` argument specifies
-the dimensions of the neighborhood that can be used to construct a diamond shape `Ω` using
-[`strel_diamond`](@ref). The `Ω` is also known as structuring element (SE), it can be either
+the dimensions of the neighborhood that can be used to construct a box shape `Ω` using
+[`strel_box`](@ref). The `Ω` is also known as structuring element (SE), it can be either
 displacement offsets or bool array mask, please refer to [`strel`](@ref) for more details.
 
 # Examples
 
-```jldoctest; setup=:(using ImageMorphology)
+```jldoctest extreme_filter; setup=:(using ImageMorphology)
 julia> M = [4 6 5 3 4; 8 6 9 4 8; 7 8 4 9 6; 6 2 2 1 7; 1 6 5 2 6]
 5×5 Matrix{$Int}:
  4  6  5  3  4
@@ -30,13 +30,13 @@ julia> M = [4 6 5 3 4; 8 6 9 4 8; 7 8 4 9 6; 6 2 2 1 7; 1 6 5 2 6]
 
 julia> extreme_filter(max, M) # max-filter using 4 direct neighbors along both dimensions
 5×5 Matrix{$Int}:
- 8  6  9  5  8
  8  9  9  9  8
+ 8  9  9  9  9
+ 8  9  9  9  9
  8  8  9  9  9
- 7  8  5  9  7
- 6  6  6  6  7
+ 6  6  6  7  7
 
-julia> extreme_filter(max, M; dims=(1, )) # max-filter along the first dimension (column)
+julia> extreme_filter(max, M; dims=1) # max-filter along the first dimension (column)
 5×5 Matrix{$Int}:
  8  6  9  4  8
  8  8  9  9  8
@@ -49,9 +49,9 @@ julia> extreme_filter(max, M; dims=(1, )) # max-filter along the first dimension
 connectivity, or a `AbstractArray{<:CartesianIndex}` array with each element indicating the
 displacement offset to its center element.
 
-```
-julia> Ω_mask = Bool[1 1 0; 1 1 0; 1 0 0] # custom neighborhood in mask format
-3×3 Matrix{Bool}:
+```jldoctest extreme_filter
+julia> Ω_mask = centered(Bool[1 1 0; 1 1 0; 1 0 0]) # custom neighborhood in mask format
+3×3 OffsetArray(::Matrix{Bool}, -1:1, -1:1) with eltype Bool with indices -1:1×-1:1:
  1  1  0
  1  1  0
  1  0  0
@@ -78,7 +78,7 @@ true
 See also the in-place version [`extreme_filter!`](@ref). Another function in ImageFiltering
 package `ImageFiltering.mapwindow` provides similar functionality.
 """
-extreme_filter(f, A; dims::Dims=coords_spatial(A)) = extreme_filter(f, A, strel_diamond(A, dims))
+extreme_filter(f, A; dims::Dims=coords_spatial(A)) = extreme_filter(f, A, strel_box(A, dims))
 extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 
 """
@@ -88,8 +88,8 @@ extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 The in-place version of [`extreme_filter`](@ref) where `out` is the output array that gets
 modified.
 """
-extreme_filter!(f, out, A, dims::Dims) = extreme_filter!(f, out, A, strel_diamond(A, dims))
-function extreme_filter!(f, out, A, Ω::AbstractArray=strel_diamond(A))
+extreme_filter!(f, out, A, dims::Dims) = extreme_filter!(f, out, A, strel_box(A, dims))
+function extreme_filter!(f, out, A, Ω::AbstractArray=strel_box(A))
     axes(out) == axes(A) || throw(DimensionMismatch("axes(out) must match axes(A)"))
     return _extreme_filter!(strel_type(Ω), f, out, A, Ω)
 end

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -1,4 +1,4 @@
-const MAX_OR_MIN = Union{typeof(max), typeof(min)}
+const MAX_OR_MIN = Union{typeof(max),typeof(min)}
 
 """
     extreme_filter(f, A; [dims]) -> out
@@ -91,14 +91,14 @@ modified.
 extreme_filter!(f, out, A, dims::Dims) = extreme_filter!(f, out, A, strel_diamond(A, dims))
 function extreme_filter!(f, out, A, Ω::AbstractArray=strel_diamond(A))
     axes(out) == axes(A) || throw(DimensionMismatch("axes(out) must match axes(A)"))
-    _extreme_filter!(strel_type(Ω), f, out, A, Ω)
+    return _extreme_filter!(strel_type(Ω), f, out, A, Ω)
 end
 
 _extreme_filter!(::MorphologySE, f, out, A, Ω) = _extreme_filter_generic!(f, out, A, Ω)
 _extreme_filter!(::SEDiamond, f, out, A, Ω) = _extreme_filter_diamond!(f, out, A, Ω)
-function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where T<:Union{Gray{Bool},Bool}
+function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where {T<:Union{Gray{Bool},Bool}}
     # NOTE(johnnychen94): empirical choice based on benchmark results (intel i9-12900k)
-    true_ratio = gray(sum(A)/length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
+    true_ratio = gray(sum(A) / length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
     true_ratio == 1 && (out .= true; return out)
     true_ratio == 0 && (out .= false; return out)
     use_bool = prod(strel_size(Ω)) > 9 || (f === max && true_ratio > 0.8) || (f === min && true_ratio < 0.2)
@@ -108,9 +108,9 @@ function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T
         return _extreme_filter_generic!(f, out, A, Ω)
     end
 end
-function _extreme_filter!(::SEDiamond, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where T<:Union{Gray{Bool},Bool}
+function _extreme_filter!(::SEDiamond, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where {T<:Union{Gray{Bool},Bool}}
     # NOTE(johnnychen94): empirical choice based on benchmark results (intel i9-12900k)
-    true_ratio = gray(sum(A)/length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
+    true_ratio = gray(sum(A) / length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
     true_ratio == 1 && (out .= true; return out)
     true_ratio == 0 && (out .= false; return out)
     use_bool = (f === max && true_ratio > 0.4) || (f === min && true_ratio < 0.6)
@@ -127,12 +127,12 @@ end
 ###
 
 function _extreme_filter_generic!(f, out, A, Ω)
-    @debug "call the generic `extreme_filter` implementation" fname=_extreme_filter_generic!
+    @debug "call the generic `extreme_filter` implementation" fname = _extreme_filter_generic!
     Ω = strel(CartesianIndex, Ω)
     δ = CartesianIndex(strel_size(Ω) .÷ 2)
 
     R = CartesianIndices(A)
-    R_inner = (first(R)+δ):(last(R)-δ)
+    R_inner = (first(R) + δ):(last(R) - δ)
 
     # NOTE(johnnychen94): delibrately duplicate the kernel codes here for inner loop and
     # boundary loop, because keeping the big function body allows Julia to do further
@@ -141,7 +141,7 @@ function _extreme_filter_generic!(f, out, A, Ω)
         # for interior points, boundary check is unnecessary
         s = A[p]
         for o in Ω
-            v = A[p+o]
+            v = A[p + o]
             s = f(s, v)
         end
         out[p] = s
@@ -150,7 +150,7 @@ function _extreme_filter_generic!(f, out, A, Ω)
         # for edge points, skip if the offset exceeds the boundary
         s = A[p]
         for o in Ω
-            q = p+o
+            q = p + o
             checkbounds(Bool, A, q) || continue
             s = f(s, A[q])
         end
@@ -161,12 +161,12 @@ end
 
 # optimized implementation for SEDiamond -- a typical case of separable filter
 function _extreme_filter_diamond!(f, out, A, Ω::SEDiamondArray)
-    @debug "call the optimized `extreme_filter` implementation for SEDiamond SE" fname=_extreme_filter_diamond!
+    @debug "call the optimized `extreme_filter` implementation for SEDiamond SE" fname = _extreme_filter_diamond!
     rΩ = strel_size(Ω) .÷ 2
     r = maximum(rΩ)
 
     # To avoid the result affected by loop order, we need two arrays
-    src = (out === A) || (r>1) ? copy(A) : A
+    src = (out === A) || (r > 1) ? copy(A) : A
     out .= src
 
     # applying radius=r filter is equivalent to applying radius=1 filter r times
@@ -179,8 +179,8 @@ function _extreme_filter_diamond!(f, out, A, Ω::SEDiamondArray)
             if size(out, d) == 1 || rΩ[d] == 0
                 continue
             end
-            Rpre = CartesianIndices(inds[1:d-1])
-            Rpost = CartesianIndices(inds[d+1:end])
+            Rpre = CartesianIndices(inds[1:(d - 1)])
+            Rpost = CartesianIndices(inds[(d + 1):end])
             _extreme_filter_C2!(f, out, src, Rpre, inds[d], Rpost)
         end
 
@@ -197,20 +197,20 @@ end
     # for r>1 case, it is equivalently to apply r times
     @inbounds for Ipost in Rpost, Ipre in Rpre
         # loop inner region
-        for i in first(inds)+1:last(inds)-1
-            a1 = src[Ipre, i-1, Ipost]
+        for i in (first(inds) + 1):(last(inds) - 1)
+            a1 = src[Ipre, i - 1, Ipost]
             a2 = dst[Ipre, i, Ipost]
-            a3 = src[Ipre, i+1, Ipost]
+            a3 = src[Ipre, i + 1, Ipost]
             dst[Ipre, i, Ipost] = f(f(a1, a2), a3)
         end
         # process two edge points
         i = first(inds)
         a2 = dst[Ipre, i, Ipost]
-        a3 = src[Ipre, i+1, Ipost]
+        a3 = src[Ipre, i + 1, Ipost]
         dst[Ipre, i, Ipost] = f(a2, a3)
 
         i = last(inds)
-        a1 = src[Ipre, i-1, Ipost]
+        a1 = src[Ipre, i - 1, Ipost]
         a2 = dst[Ipre, i, Ipost]
         dst[Ipre, i, Ipost] = f(a1, a2)
     end
@@ -221,12 +221,12 @@ end
 # 1) use &&, || instead of max, min
 # 2) short-circuit the result to avoid unnecessary indexing and computation
 function _extreme_filter_bool!(f, out, A::AbstractArray{Bool}, Ω)
-    @debug "call the optimized max/min `extreme_filter` implementation for boolean array" fname=_extreme_filter_bool!
+    @debug "call the optimized max/min `extreme_filter` implementation for boolean array" fname = _extreme_filter_bool!
     Ω = strel(CartesianIndex, Ω)
     δ = CartesianIndex(strel_size(Ω) .÷ 2)
 
     R = CartesianIndices(A)
-    R_inner = (first(R)+δ):(last(R)-δ)
+    R_inner = (first(R) + δ):(last(R) - δ)
 
     select = _fast_select(f)
     @inbounds for p in R_inner
@@ -247,7 +247,7 @@ Base.@propagate_inbounds function _maximum_fast(A::AbstractArray{Bool}, p, Ω)
     for o in Ω
         # the complicated control flow ruins the SIMD and thus for small Ω, the performance
         # will be worse
-        q = p+o
+        q = p + o
         @boundscheck checkbounds(Bool, A, q) || continue
         x = A[q]
         x && return true
@@ -260,7 +260,7 @@ Base.@propagate_inbounds function _minimum_fast(A::AbstractArray{Bool}, p, Ω)
     for o in Ω
         # the complicated control flow ruins the SIMD and thus for small Ω, the performance
         # will be worse
-        q = p+o
+        q = p + o
         @boundscheck checkbounds(Bool, A, q) || continue
         x = A[q]
         x || return false

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -78,7 +78,7 @@ true
 See also the in-place version [`extreme_filter!`](@ref). Another function in ImageFiltering
 package `ImageFiltering.mapwindow` provides similar functionality.
 """
-extreme_filter(f, A; dims::Dims=coords_spatial(A)) = extreme_filter(f, A, strel_box(A, dims))
+extreme_filter(f, A; dims=coords_spatial(A)) = extreme_filter(f, A, strel_box(A, dims))
 extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 
 """
@@ -88,7 +88,7 @@ extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 The in-place version of [`extreme_filter`](@ref) where `out` is the output array that gets
 modified.
 """
-extreme_filter!(f, out, A, dims::Dims) = extreme_filter!(f, out, A, strel_box(A, dims))
+extreme_filter!(f, out, A, dims) = extreme_filter!(f, out, A, strel_box(A, dims))
 function extreme_filter!(f, out, A, Ω::AbstractArray=strel_box(A))
     axes(out) == axes(A) || throw(DimensionMismatch("axes(out) must match axes(A)"))
     return _extreme_filter!(strel_type(Ω), f, out, A, Ω)

--- a/test/extreme_filter.jl
+++ b/test/extreme_filter.jl
@@ -3,7 +3,7 @@
         # Bool
         img = fill(false, 5, 5)
         img[3, 3] = 1
-        ref = collect(strel_diamond((5, 5); r=1))
+        ref = collect(strel_box((5, 5); r=1))
 
         img_d = @inferred extreme_filter(max, img)
         @test img_d == ref
@@ -12,6 +12,9 @@
         # Int
         A = Int[4 6 5 3 4; 8 6 9 4 8; 7 8 4 9 6; 6 2 2 1 7; 1 6 5 2 6]
         ref = [8 6 9 5 8; 8 9 9 9 8; 8 8 9 9 9; 7 8 5 9 7; 6 6 6 6 7]
+        Ad = @inferred extreme_filter(max, A, strel_diamond(A))
+        @test Ad == ref
+        ref = [8 9 9 9 8; 8 9 9 9 9; 8 9 9 9 9; 8 8 9 9 9; 6 6 6 7 7]
         Ad = @inferred extreme_filter(max, A)
         @test Ad == ref
 

--- a/test/extreme_filter.jl
+++ b/test/extreme_filter.jl
@@ -1,7 +1,8 @@
 @testset "extreme_filter" begin
     @testset "numerical" begin
         # Bool
-        img = fill(false, 5, 5); img[3, 3] = 1
+        img = fill(false, 5, 5)
+        img[3, 3] = 1
         ref = collect(strel_diamond((5, 5); r=1))
 
         img_d = @inferred extreme_filter(max, img)
@@ -15,9 +16,9 @@
         @test Ad == ref
 
         # Gray{Float32}
-        img = Gray{Float32}.(A./9)
+        img = Gray{Float32}.(A ./ 9)
         img_d = @inferred extreme_filter(max, img)
-        @test ref == gray.(img_d).*9
+        @test ref == gray.(img_d) .* 9
     end
 
     @testset "strel" begin
@@ -32,12 +33,12 @@
     @testset "optimization: diamond" begin
         # ensure the optimized implementation work equivalently to the generic fallback implementation
         for N in (1, 2, 3)
-            sz = ntuple(_->32, N)
+            sz = ntuple(_ -> 32, N)
             img = rand(sz...)
             for r in (1, 3)
-                dims_list = ntuple(i->ntuple(identity, i), N)
+                dims_list = ntuple(i -> ntuple(identity, i), N)
                 for dims in dims_list
-                    se = strel_diamond(ntuple(_->2r+1, N), dims)
+                    se = strel_diamond(ntuple(_ -> 2r + 1, N), dims)
                     ref = ImageMorphology._extreme_filter_generic!(max, similar(img), img, se)
                     out = extreme_filter(max, img, se)
                     @test out == ref
@@ -49,12 +50,12 @@
     @testset "optimization: bool" begin
         # ensure the optimized implementation work equivalently to the generic fallback implementation
         for N in (1, 2, 3)
-            sz = ntuple(_->32, N)
+            sz = ntuple(_ -> 32, N)
             img = rand(Bool, sz...)
             for r in (1, 3)
-                dims_list = ntuple(i->ntuple(identity, i), N)
+                dims_list = ntuple(i -> ntuple(identity, i), N)
                 for dims in dims_list, select in (max, min)
-                    se = strel_diamond(ntuple(_->2r+1, N), dims)
+                    se = strel_diamond(ntuple(_ -> 2r + 1, N), dims)
                     ref = ImageMorphology._extreme_filter_generic!(select, similar(img), img, se)
                     out = extreme_filter(select, img, se) # SEDiamond method
                     @test out == ref


### PR DESCRIPTION
This changes the default se for the new `extreme_filter` to be box shape, i.e., C8 for 2d, C27 for 3d. This is consistent with the previous `extremefilt!` implementation.

fixes #68

This will be a breaking change, so the next release ImageMorphology will be 0.4.0.

cc: @ThomasRetornaz