### PR TITLE
add half-size keyword `r` to basic operations

### DIFF
--- a/src/ops/closing.jl
+++ b/src/ops/closing.jl
@@ -1,17 +1,11 @@
 """
-    closing(img; [dims])
+    closing(img; dims=coords_spatial(img), r=1)
     closing(img, se)
 
-Perform the morphological closing on `img`. Mathematically, a closing operation is
-[dilation](@ref dilate) followed by a [erosion](@ref erode):
+Perform the morphological closing on `img`.The closing operation is defined as
+[dilation](@ref dilate) followed by a [erosion](@ref erode): `erode(dilate(img, se), se)`.
 
-```julia
-closing(img, se) = erode(dilate(img, se), se)
-```
-
-`se` is the structuring element that defines the neighborhood of the image. See
-[`strel`](@ref) for more details. If `se` is not specified, then it will use the
-[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter.
+$(_docstring_se)
 
 # Examples
 
@@ -53,7 +47,7 @@ julia> closing(img, strel_diamond(img)) # # use diamond shape SE
 - [`closing`](@ref) is the dual operator of `opening` in the sense that
   `complement.(opening(img)) == closing(complement.(img))`.
 """
-closing(img; dims=coords_spatial(img)) = closing!(similar(img), img, similar(img); dims)
+closing(img; kwargs...) = closing!(similar(img), img, similar(img); kwargs...)
 closing(img, se) = closing!(similar(img), img, se, similar(img))
 
 """
@@ -63,9 +57,12 @@ closing(img, se) = closing!(similar(img), img, se, similar(img))
 The in-place version of [`closing`](@ref) with input image `img` and output image `out`. The
 intermediate dilation result is stored in `buffer`.
 """
-closing!(out, img, buffer; dims=coords_spatial(img)) = closing!(out, img, strel_box(img, dims), buffer)
+function closing!(out, img, buffer; dims=coords_spatial(img), r=nothing)
+    return closing!(out, img, strel_box(img, dims; r), buffer)
+end
 function closing!(out, img, se, buffer)
     dilate!(buffer, img, se)
     erode!(out, buffer, se)
     return out
 end
+closing!(out::AbstractArray{<:Color3}, img, se, buffer) = throw(ArgumentError("color image is not supported"))

--- a/src/ops/dilate.jl
+++ b/src/ops/dilate.jl
@@ -1,12 +1,10 @@
 """
-    dilate(img; [dims])
+    dilate(img; dims=coords_spatial(img), r=1)
     dilate(img, se)
 
 Perform a max-filter over the neighborhood of `img`, specified by structuring element `se`.
 
-`se` is the structuring element that defines the neighborhood of the image. See
-[`strel`](@ref) for more details. If `se` is not specified, then it will use the
-[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter.
+$(_docstring_se)
 
 # Examples
 
@@ -55,7 +53,7 @@ julia> dilate(img, strel_diamond(img)) # use diamond shape SE
     dilation becomes the Minkowski sum: A⊕B={a+b|a∈A, b∈B}.
 
 """
-dilate(img::AbstractArray; dims=coords_spatial(img)) = dilate!(similar(img), img; dims)
+dilate(img::AbstractArray; kwargs...) = dilate!(similar(img), img; kwargs...)
 dilate(img::AbstractArray, se::AbstractArray) = dilate!(similar(img), img, se)
 
 """
@@ -64,5 +62,8 @@ dilate(img::AbstractArray, se::AbstractArray) = dilate!(similar(img), img, se)
 
 The in-place version of [`dilate`](@ref) with input image `img` and output image `out`.
 """
-dilate!(out, img; dims=coords_spatial(img)) = dilate!(out, img, strel_box(img, dims))
+function dilate!(out, img; dims=coords_spatial(img), r=nothing)
+    return dilate!(out, img, strel_box(img, dims; r))
+end
 dilate!(out, img, se::AbstractArray) = extreme_filter!(max, out, img, se)
+dilate!(out::AbstractArray{<:Color3}, img, se::AbstractArray) = throw(ArgumentError("color image is not supported"))

--- a/src/ops/erode.jl
+++ b/src/ops/erode.jl
@@ -1,12 +1,10 @@
 """
-    out = erode(img; [dims])
+    out = erode(img; dims=coords_spatial(img), r=1)
     out = erode(img, se)
 
 Perform a min-filter over the neighborhood of `img`, specified by structuring element `se`.
 
-`se` is the structuring element that defines the neighborhood of the image. See
-[`strel`](@ref) for more details. If `se` is not specified, then it will use the
-[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter.
+$(_docstring_se)
 
 # Examples
 
@@ -54,7 +52,7 @@ julia> erode(img, strel_diamond(img)) # use diamond shape SE
     If `se` is symmetric with repsect to origin, i.e., `se[b] == se[-b]` for any `b`, then
     erosion becomes the Minkowski difference: A⊖B={a-b|a∈A, b∈B}.
 """
-erode(img::AbstractArray; dims=coords_spatial(img)) = erode!(similar(img), img; dims)
+erode(img::AbstractArray; kwargs...) = erode!(similar(img), img; kwargs...)
 erode(img::AbstractArray, se::AbstractArray) = erode!(similar(img), img, se)
 
 """
@@ -63,5 +61,8 @@ erode(img::AbstractArray, se::AbstractArray) = erode!(similar(img), img, se)
 
 The in-place version of [`erode`](@ref) with input image `img` and output image `out`.
 """
-erode!(out, img; dims=coords_spatial(img)) = erode!(out, img, strel_box(img, dims))
+function erode!(out, img; dims=coords_spatial(img), r=nothing)
+    return erode!(out, img, strel_box(img, dims; r))
+end
 erode!(out, img, se::AbstractArray) = extreme_filter!(min, out, img, se)
+erode!(out::AbstractArray{<:Color3}, img, se::AbstractArray) = throw(ArgumentError("color image is not supported"))

--- a/src/ops/morphogradient.jl
+++ b/src/ops/morphogradient.jl
@@ -1,13 +1,11 @@
 """
-    morphogradient(img; dims=coords_spatial(img))
+    morphogradient(img; dims=coords_spatial(img), r=1)
     morphogradient(img, se)
 
 Calculate morphological (Beucher) gradient of the image, i.e., `dilate(img, se) - erode(img,
 se)`.
 
-`se` is the structuring element that defines the neighborhood of the image. See
-[`strel`](@ref) for more details. If `se` is not specified, then it will use the
-[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter.
+$(_docstring_se)
 
 # Examples
 
@@ -22,8 +20,8 @@ julia> img = falses(7, 7); img[3:5, 3:5] .= true; img
  0  0  0  0  0  0  0
  0  0  0  0  0  0  0
 
-julia> BitArray(morphogradient(img))
-7×7 BitMatrix:
+julia> Int.(morphogradient(img))
+7×7 Matrix{$Int}:
  0  0  0  0  0  0  0
  0  1  1  1  1  1  0
  0  1  1  1  1  1  0
@@ -32,8 +30,8 @@ julia> BitArray(morphogradient(img))
  0  1  1  1  1  1  0
  0  0  0  0  0  0  0
 
-julia> BitArray(morphogradient(img, strel_diamond(img))) # use diamond shape SE
-7×7 BitMatrix:
+julia> Int.(morphogradient(img, strel_diamond(img))) # use diamond shape SE
+7×7 Matrix{$Int}:
  0  0  0  0  0  0  0
  0  0  1  1  1  0  0
  0  1  1  1  1  1  0
@@ -49,10 +47,13 @@ julia> BitArray(morphogradient(img, strel_diamond(img))) # use diamond shape SE
 - `ImageBase.FiniteDiff` also provides a few finite difference operators, including `fdiff`,
   `fgradient`, etc.
 """
-morphogradient(img; dims=coords_spatial(img)) = morphogradient(img, strel_box(img, dims))
+function morphogradient(img; dims=coords_spatial(img), r=nothing)
+    return morphogradient(img, strel_box(img, dims; r))
+end
 function morphogradient(img::AbstractArray{T}, se) where {T}
     buffer = similar(img)
     out = dilate!(similar(img, maybe_floattype(T)), img, se)
     buffer = erode!(similar(img, maybe_floattype(T)), img, se)
     return out .- buffer
 end
+morphogradient(img::AbstractArray{<:Color3}, se) = throw(ArgumentError("color image is not supported"))

--- a/src/ops/morpholaplace.jl
+++ b/src/ops/morpholaplace.jl
@@ -1,5 +1,5 @@
 """
-    morpholaplace(img; dims=coords_spatial(img))
+    morpholaplace(img; dims=coords_spatial(img), r=1)
     morpholaplace(img, se)
 
 Calculate morphological laplacian of the image.
@@ -52,10 +52,13 @@ julia> Int.(morpholaplace(img, strel_diamond(img))) # use diamond shape SE
 - `ImageBase.FiniteDiff` also provides a few finite difference operators, including `fdiff`,
   `fgradient`, etc.
 """
-morpholaplace(img; dims=coords_spatial(img)) = morpholaplace(img, strel_box(img, dims))
+function morpholaplace(img; dims=coords_spatial(img), r=nothing)
+    return morpholaplace(img, strel_box(img, dims; r))
+end
 function morpholaplace(img::AbstractArray{T}, se) where {T}
     out = dilate!(similar(img, maybe_floattype(T)), img, se)
     buffer = erode!(similar(img, maybe_floattype(T)), img, se)
     @. out = out + buffer - 2img
     return out
 end
+morpholaplace(img::AbstractArray{<:Color3}, se) = throw(ArgumentError("color image is not supported"))

--- a/src/ops/opening.jl
+++ b/src/ops/opening.jl
@@ -1,17 +1,11 @@
 """
-    opening(img; [dims])
+    opening(img; dims=coords_spatial(img), r=1)
     opening(img, se)
 
-Perform the morphological opening on `img`. Mathematically, a opening operation is
-[erosion](@ref erode) followed by a [dilation](@ref dilate):
+Perform the morphological opening on `img`. The opening operation is defined as
+[erosion](@ref erode) followed by a [dilation](@ref dilate): `dilate(erode(img, se), se)`.
 
-```julia
-opening(img, se) = dilate(erode(img, se), se)
-```
-
-`se` is the structuring element that defines the neighborhood of the image. See
-[`strel`](@ref) for more details. If `se` is not specified, then it will use the
-[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter.
+$(_docstring_se)
 
 # Examples
 
@@ -53,7 +47,7 @@ julia> opening(img, strel_diamond(img)) # use diamond shape SE
 - [`closing`](@ref) is the dual operator of `opening` in the sense that
   `complement.(opening(img)) == closing(complement.(img))`.
 """
-opening(img; dims=coords_spatial(img)) = opening!(similar(img), img, similar(img); dims)
+opening(img; kwargs...) = opening!(similar(img), img, similar(img); kwargs...)
 opening(img, se) = opening!(similar(img), img, se, similar(img))
 
 """
@@ -63,9 +57,12 @@ opening(img, se) = opening!(similar(img), img, se, similar(img))
 The in-place version of [`opening`](@ref) with input image `img` and output image `out`. The
 intermediate erosion result is stored in `buffer`.
 """
-opening!(out, img, buffer; dims=coords_spatial(img)) = opening!(out, img, strel_box(img, dims), buffer)
+function opening!(out, img, buffer; dims=coords_spatial(img), r=nothing)
+    return opening!(out, img, strel_box(img, dims; r), buffer)
+end
 function opening!(out, img, se, buffer)
     erode!(buffer, img, se)
     dilate!(out, buffer, se)
     return out
 end
+opening!(out::AbstractArray{<:Color3}, img, se, buffer) = throw(ArgumentError("color image is not supported"))

--- a/src/structuring_element.jl
+++ b/src/structuring_element.jl
@@ -1,3 +1,10 @@
+const _docstring_se = """
+`se` is the structuring element that defines the neighborhood of the image. See
+[`strel`](@ref) for more details. If `se` is not specified, then it will use the
+[`strel_box`](@ref) with an extra keyword `dims` to control the dimensions to filter,
+and half-size `r` to control the diamond size.
+"""
+
 abstract type MorphologySE{N} end
 abstract type MorphologySEArray{N} <: AbstractArray{Bool,N} end
 

--- a/test/ops/bothat.jl
+++ b/test/ops/bothat.jl
@@ -1,9 +1,29 @@
+bothat_ref(img, dims, r) = bothat_ref(img, strel_box(img, dims; r))
+bothat_ref(img, se) = float.(closing(img, se)) - float.(img)
+
 @testset "bothat" begin
-    A = ones(13, 13)
-    A[2:3, 2:3] .= 0
-    Ae = 1 .- copy(A)
-    A[5:9, 5:9] .= 0
-    Ao = bothat(A)
-    @test Ao == Ae
-    @test bothat(A; dims=1:2) == Ao
+    test_ranges = [Bool, 1:10, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_ranges
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = bothat(img)
+            @test out == bothat(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == bothat_ref(img, ntuple(identity, N), 1)
+
+            @test bothat(img; dims=(1,), r=2) == bothat_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test bothat(img, se) == bothat_ref(img, se)
+        end
+    end
+
+    img = rand(1:5, 7, 7)
+    out = similar(img)
+    bothat!(out, img, similar(img))
+    @test out == bothat(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") bothat(img)
 end

--- a/test/ops/closing.jl
+++ b/test/ops/closing.jl
@@ -1,10 +1,29 @@
+closing_ref(img, dims, r) = closing_ref(img, strel_box(img, dims; r))
+closing_ref(img, se) = erode(dilate(img, se), se)
+
 @testset "closing" begin
-    A = zeros(10, 10)
-    A[4:7, 4:7] .= 1
-    B = copy(A)
-    A[5, 5] = 0
-    Ac = closing(A)
-    @test Ac == B
-    @test closing(A; dims=1:3) == Ac
-    @test closing!(similar(A), A, similar(A); dims=1:3) == Ac
+    test_types = [Bool, Int, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_types
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = closing(img)
+            @test out == closing(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == closing_ref(img, ntuple(identity, N), 1)
+
+            @test closing(img; dims=(1,), r=2) == closing_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test closing(img, se) == closing_ref(img, se)
+        end
+    end
+
+    img = rand(1:5, 7, 7)
+    out = similar(img)
+    closing!(out, img, similar(img))
+    @test out == closing(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") closing(img)
 end

--- a/test/ops/erode.jl
+++ b/test/ops/erode.jl
@@ -1,44 +1,36 @@
+erode_ref(img, dims, r) = erode_ref(img, strel_box(img, dims; r))
+erode_ref(img, se) = extreme_filter(min, img, se)
+
 @testset "erode" begin
-    A = zeros(4, 4, 3)
-    A[2, 2, 1] = 0.8
-    A[4, 4, 2] = 0.6
-    Ae = erode(A)
-    @test Ae == zeros(size(A))
-    Ad = dilate(A; dims=1:2)
-    Ar = [
-        0.8 0.8 0.8 0
-        0.8 0.8 0.8 0
-        0.8 0.8 0.8 0
-        0 0 0 0
-    ]
-    Ag = [
-        0 0 0 0
-        0 0 0 0
-        0 0 0.6 0.6
-        0 0 0.6 0.6
-    ]
-    @test Ad == cat(Ar, Ag, zeros(4, 4); dims=3)
-    @test dilate!(similar(A), A; dims=1:2) == Ad
-    Ae = erode(Ad; dims=1:2)
-    Ar = [
-        0.8 0.8 0 0
-        0.8 0.8 0 0
-        0 0 0 0
-        0 0 0 0
-    ]
-    Ag = [
-        0 0 0 0
-        0 0 0 0
-        0 0 0 0
-        0 0 0 0.6
-    ]
-    @test Ae == cat(Ar, Ag, zeros(4, 4); dims=3)
-    @test erode!(similar(Ad), Ad; dims=1:2) == Ae
-    # issue Images.jl #311
-    @test dilate(trues(3)) == trues(3)
+    test_types = [Bool, Int, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_types
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = erode(img)
+            @test out == erode(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == erode_ref(img, ntuple(identity, N), 1)
+
+            @test erode(img; dims=(1,), r=2) == erode_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test erode(img, se) == erode_ref(img, se)
+        end
+    end
+
+    img = rand(1:5, 7, 7)
+    out = similar(img)
+    erode!(out, img)
+    @test out == erode(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") erode(img)
+
     # ImageMeta
-    @test arraydata(dilate(ImageMeta(A))) == dilate(A)
-    @test arraydata(dilate(ImageMeta(A); dims=1:2)) == dilate(A; dims=1:2)
-    @test arraydata(erode(ImageMeta(A))) == erode(A)
-    @test arraydata(erode(ImageMeta(A); dims=1:2)) == erode(A; dims=1:2)
+    @testset "ImageMeta" begin
+        A = rand(1:5, 7, 7)
+        @test arraydata(erode(ImageMeta(A))) == erode(A)
+        @test arraydata(erode(ImageMeta(A); dims=1:2)) == erode(A; dims=1:2)
+    end
 end

--- a/test/ops/morphogradient.jl
+++ b/test/ops/morphogradient.jl
@@ -1,12 +1,30 @@
-@testset "Morphological Gradient" begin
-    A = zeros(13, 13)
-    A[5:9, 5:9] .= 1
-    Ao = morphogradient(A)
-    @test morphogradient(A; dims=1:2) == morphogradient(A)
-    Ae = zeros(13, 13)
-    Ae[4:10, 4:10] .= 1
-    Ae[6:8, 6:8] .= 0
-    @test Ao == Ae
-    Aee = dilate(A) - erode(A)
-    @test Aee == Ae
+beucher_gradient_ref(img, dims, r) = beucher_gradient_ref(img, strel_box(img, dims; r))
+beucher_gradient_ref(img, se) = float.(dilate(img, se)) .- float.(erode(img, se))
+
+@testset "morphogradient" begin
+    test_ranges = [Bool, 1:10, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_ranges
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = morphogradient(img)
+            @test out == morphogradient(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == beucher_gradient_ref(img, ntuple(identity, N), 1)
+
+            @test morphogradient(img; dims=(1,), r=2) == beucher_gradient_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test morphogradient(img, se) == beucher_gradient_ref(img, se)
+        end
+    end
+
+    # TODO(johnnychen94): support this
+    # img = rand(1:5, 7, 7)
+    # out = similar(img)
+    # morphogradient!(out, img, similar(img))
+    # @test out == morphogradient(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") morphogradient(img)
 end

--- a/test/ops/morpholaplace.jl
+++ b/test/ops/morpholaplace.jl
@@ -1,13 +1,30 @@
-@testset "Morphological Laplacian" begin
-    A = zeros(13, 13)
-    A[5:9, 5:9] .= 1
-    Ao = morpholaplace(A)
-    @test morpholaplace(A; dims=1:2) == Ao
-    Ae = zeros(13, 13)
-    Ae[4:10, 4:10] .= 1
-    Ae[5:9, 5:9] .= -1
-    Ae[6:8, 6:8] .= 0
-    @test Ao == Ae
-    Aee = dilate(A) + erode(A) - 2A
-    @test Aee == Ae
+morpholaplace_ref(img, dims, r) = morpholaplace_ref(img, strel_box(img, dims; r))
+morpholaplace_ref(img, se) = float.(dilate(img, se)) .+ float.(erode(img, se)) .- 2 .* float.(img)
+
+@testset "morpholaplace" begin
+    test_ranges = [Bool, 1:10, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_ranges
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = morpholaplace(img)
+            @test out == morpholaplace(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == morpholaplace_ref(img, ntuple(identity, N), 1)
+
+            @test morpholaplace(img; dims=(1,), r=2) == morpholaplace_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test morpholaplace(img, se) == morpholaplace_ref(img, se)
+        end
+    end
+
+    # TODO(johnnychen94): support this
+    # img = rand(1:5, 7, 7)
+    # out = similar(img)
+    # morpholaplace!(out, img, similar(img))
+    # @test out == morpholaplace(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") morpholaplace(img)
 end

--- a/test/ops/tophat.jl
+++ b/test/ops/tophat.jl
@@ -1,11 +1,29 @@
+tophat_ref(img, dims, r) = tophat_ref(img, strel_box(img, dims; r))
+tophat_ref(img, se) = float.(img) .- float.(opening(img, se))
+
 @testset "tophat" begin
-    A = zeros(13, 13)
-    A[2:3, 2:3] .= 1
-    Ae = copy(A)
-    A[5:9, 5:9] .= 1
-    Ao = tophat(A)
-    @test Ao == Ae
-    @test tophat(A; dims=1:2) == Ae
-    Aoo = tophat(Ae)
-    @test Aoo == Ae
+    test_ranges = [Bool, 1:10, Float64, Gray{N0f8}, Gray{Float64}]
+    for T in test_ranges
+        for N in (1, 2, 3)
+            sz = ntuple(_ -> 32, N)
+            img = rand(T, sz...)
+
+            out = tophat(img)
+            @test out == tophat(img, strel_box(img, ntuple(identity, N); r=1))
+            @test out == tophat_ref(img, ntuple(identity, N), 1)
+
+            @test tophat(img; dims=(1,), r=2) == tophat_ref(img, (1,), 2)
+
+            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            @test tophat(img, se) == tophat_ref(img, se)
+        end
+    end
+
+    img = rand(1:5, 7, 7)
+    out = similar(img)
+    tophat!(out, img, similar(img))
+    @test out == tophat(img)
+
+    img = rand(RGB, 7, 7)
+    @test_throws ArgumentError("color image is not supported") tophat(img)
 end


### PR DESCRIPTION
For `erode`, `dilate`, `closing`, `opening`, `bothat`, `tophat`, `morphogradient` and `morpholaplace`:

- add keyword `r` for convenient usage
- rewrite the tests to cover more usage -- because they are mainly direct usage of `extreme_filter`, we only need to test the interfaces to ensure the behavior