### PR TITLE
fix: use symmetric se for tests in gradient ops

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,4 +35,4 @@ is_symmetric(se::SEDiamondArray) = true
 Some morphological operation only makes sense for symmetric structuring elements.
 Here we provide a checker in spirit of Base.require_one_based_idnexing.
 =#
-require_symmetric_strel(se) = is_symmetric(se) || throw(ArgumentError("Structuring element must be symmetric with respect to its center"))
+require_symmetric_strel(se) = is_symmetric(se) || throw(ArgumentError("structuring element must be symmetric with respect to its center"))

--- a/test/ops/morphogradient.jl
+++ b/test/ops/morphogradient.jl
@@ -14,7 +14,7 @@ beucher_gradient_ref(img, se) = float.(dilate(img, se)) .- float.(erode(img, se)
 
             @test morphogradient(img; dims=(1,), r=2) == beucher_gradient_ref(img, (1,), 2)
 
-            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            se = rand_se_mask(3, N; symmetric=true)
             @test morphogradient(img, se) == beucher_gradient_ref(img, se)
         end
     end
@@ -27,4 +27,9 @@ beucher_gradient_ref(img, se) = float.(dilate(img, se)) .- float.(erode(img, se)
 
     img = rand(RGB, 7, 7)
     @test_throws ArgumentError("color image is not supported") morphogradient(img)
+
+    img = rand(1:10, 7, 7)
+    se = Bool[1 0 0; 0 1 0; 0 0 0]
+    msg = "structuring element must be symmetric with respect to its center"
+    @test_throws ArgumentError(msg) morpholaplace(img, se)
 end

--- a/test/ops/morpholaplace.jl
+++ b/test/ops/morpholaplace.jl
@@ -14,7 +14,7 @@ morpholaplace_ref(img, se) = float.(dilate(img, se)) .+ float.(erode(img, se)) .
 
             @test morpholaplace(img; dims=(1,), r=2) == morpholaplace_ref(img, (1,), 2)
 
-            se = centered(rand(Bool, ntuple(_ -> 3, N)))
+            se = rand_se_mask(3, N; symmetric=true)
             @test morpholaplace(img, se) == morpholaplace_ref(img, se)
         end
     end
@@ -27,4 +27,9 @@ morpholaplace_ref(img, se) = float.(dilate(img, se)) .+ float.(erode(img, se)) .
 
     img = rand(RGB, 7, 7)
     @test_throws ArgumentError("color image is not supported") morpholaplace(img)
+
+    img = rand(1:10, 7, 7)
+    se = Bool[1 0 0; 0 1 0; 0 0 0]
+    msg = "structuring element must be symmetric with respect to its center"
+    @test_throws ArgumentError(msg) morpholaplace(img, se)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Suppressor
 using Documenter
 Base.VERSION >= v"1.6" && doctest(ImageMorphology; manual=false)
 
+include("testutils.jl")
 @testset "ImageMorphology" begin
     include("structuring_element.jl")
     include("utils.jl")

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,13 @@
+# build a random mask se with extra symmetricity constraint
+function rand_se_mask(r, N; symmetric=false)
+    se = centered(rand(Bool, ntuple(_ -> r, N)))
+    symmetric || return se
+    dual_se = copy(se)
+    for i in CartesianIndices(dual_se)
+        dual_se[i] = se[-i]
+    end
+
+    out = @. (Int(dual_se) + Int(se)) ÷ 2
+    out[OffsetArrays.center(out)...] = 1
+    return Bool.(out)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -21,3 +21,11 @@
     @test ImageMorphology.is_symmetric(strel_box((3, 3)))
     @test ImageMorphology.is_symmetric(strel_diamond((3, 3)))
 end
+
+@testset "require_symmetric_strel" begin
+    se = rand_se_mask(3, 2; symmetric=true)
+    @test_nowarn ImageMorphology.require_symmetric_strel(se)
+    se = Bool[1 0 0; 0 1 0; 0 0 0]
+    msg = "structuring element must be symmetric with respect to its center"
+    @test_throws ArgumentError(msg) ImageMorphology.require_symmetric_strel(se)
+end


### PR DESCRIPTION
https://github.com/JuliaImages/ImageMorphology.jl/pull/82 requires
the se to be symmetric