### PR TITLE
revisit label_components: add new SE support

### DIFF
--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -77,7 +77,7 @@ export
     component_boxes,
     component_lengths,
     component_indices,
-    component_subscripts,
+    component_subscripts, # deprecated (v0.4)
     component_centroids,
 
     # convexhull.jl

--- a/src/StructuringElements/strel_box.jl
+++ b/src/StructuringElements/strel_box.jl
@@ -113,24 +113,25 @@ julia> strel_box((5,5); r=(1,2))
 See also [`strel`](@ref) and [`strel_box`](@ref).
 """
 function strel_box(A::AbstractArray{T,N}, dims=coords_spatial(A); r::Union{Nothing,Dims{N},Int}=nothing) where {T,N}
+    dims = _to_dims(Val(N), dims)
     sz, r = if isnothing(r)
-        ntuple(i -> in(i, dims) ? 3 : 1, N), 1
+        ntuple(i -> !isempty(dims) && in(i, dims) ? 3 : 1, N), 1
     elseif r isa Dims{N}
-        ntuple(i -> in(i, dims) ? 2r[i] + 1 : 1, N), r
+        ntuple(i -> !isempty(dims) && in(i, dims) ? 2r[i] + 1 : 1, N), r
     elseif r isa Integer
-        ntuple(i -> in(i, dims) ? 2r + 1 : 1, N), r
+        ntuple(i -> !isempty(dims) && in(i, dims) ? 2r + 1 : 1, N), r
     end
     return strel_box(sz, dims)
 end
 function strel_box(sz::Dims{N}, dims=ntuple(identity, N); r::Union{Nothing,Dims{N},Int}=nothing) where {N}
-    dims = _to_dims(dims)
+    dims = _to_dims(Val(N), dims)
     all(isodd, sz) || throw(ArgumentError("size should be odd integers"))
     radius = if isnothing(r)
-        ntuple(i -> in(i, dims) ? sz[i] ÷ 2 : 0, N)
+        ntuple(i -> !isempty(dims) && in(i, dims) ? sz[i] ÷ 2 : 0, N)
     elseif r isa Dims{N}
         r
     elseif r isa Integer
-        ntuple(i -> in(i, dims) ? r : 0, N)
+        ntuple(i -> !isempty(dims) && in(i, dims) ? r : 0, N)
     end
     ax = map(r -> (-r):r, sz .÷ 2)
     return SEBoxArray(SEBox{N}(ax; r=radius))

--- a/src/clearborder.jl
+++ b/src/clearborder.jl
@@ -18,8 +18,7 @@ function clearborder(img::AbstractArray, width::Integer=1, background::Integer=0
         end
     end
 
-    connectivity = ntuple(i -> 3, ndims(img))
-    labels = label_components(img, trues(connectivity))
+    labels = label_components(img, strel_box(img))
     number = maximum(labels) + 1
 
     dimensions = size(img)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,9 +1,4 @@
 #! format: off
-@deprecate label_components(A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0) label_components(A; bkg=bkg, dims=region)
-@deprecate label_components(A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}   label_components(A, connectivity; bkg=bkg)
-@deprecate label_components!(out::AbstractArray{Int}, A::AbstractArray, region::Union{Dims, AbstractVector{Int}}, bkg = 0)  label_components!(out, A; bkg=bkg, dims=region)
-@deprecate label_components!(out::AbstractArray{Int,N}, A::AbstractArray{T,N}, connectivity::Array{Bool,N}, bkg) where {T,N}  label_components!(out, A, connectivity; bkg=bkg)
-
 @deprecate imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, dims::Union{Dims, AbstractVector{Int}}) imfill(img, interval; dims=dims)
 
 @deprecate dilate!(img; kwargs...) dilate!(img, copy(img); kwargs...)

--- a/src/imfill.jl
+++ b/src/imfill.jl
@@ -54,7 +54,7 @@ function _imfill(img::AbstractArray{Bool}, interval::Tuple{Real,Real}, labels)
 
     new_img = similar(img)
     for ind in eachindex(img)
-        if img[ind] == true && interval[1] <= count_labels[labels[ind] + 1] <= interval[2]
+        if img[ind] == true && interval[1] <= count_labels[labels[ind]] <= interval[2]
             new_img[ind] = false
         else
             new_img[ind] = img[ind]

--- a/test/connected.jl
+++ b/test/connected.jl
@@ -1,43 +1,88 @@
-@testset "Label components" begin
-    A = [
-        true  true  false true
-        true  false true  true
-    ]
-    lbltarget = [
-        1 1 0 2
-        1 0 2 2
-    ]
-    lbltarget1 = [
-        1 2 0 4
-        1 0 3 4
-    ]
-    @test label_components(A) == lbltarget
-    @test label_components(A; dims=:) == lbltarget
-    @test label_components(A; dims=1) == lbltarget1
-    connectivity = [
-        false true  false
-        true  false true
-        false true  false
-    ]
-    @test label_components(A, connectivity) == lbltarget
-    connectivity = trues(3, 3)
-    lbltarget2 = [
-        1 1 0 1
-        1 0 1 1
-    ]
-    @test label_components(A, connectivity) == lbltarget2
-    @test component_boxes(lbltarget) ==
-        Vector{Tuple}[[(1, 2), (2, 3)], [(1, 1), (2, 2)], [(1, 3), (2, 4)]]
-    @test component_lengths(lbltarget) == [2, 3, 3]
-    @test component_indices(lbltarget) == Array{Int}[[4, 5], [1, 2, 3], [6, 7, 8]]
-    @test component_subscripts(lbltarget) ==
-        Array{Tuple}[[(2, 2), (1, 3)], [(1, 1), (2, 1), (1, 2)], [(2, 3), (1, 4), (2, 4)]]
-    @test @inferred(component_centroids(lbltarget)) ==
-        Tuple[(1.5, 2.5), (4 / 3, 4 / 3), (5 / 3, 11 / 3)]
+@testset "Connected components" begin
+    @testset "label_components" begin
+        @testset "interface" begin
+            for T in (Bool, N0f8, Float64, Gray{N0f8})
+                A = rand(T, 11, 11)
+                @test label_components(A) == label_components(A, strel_diamond(A))
+                @test label_components(A; r=2, dims=1) == label_components(A, strel_diamond(A, 1; r=2))
 
-    @test label_components!(zeros(UInt8, 240), trues(240); dims=()) == 1:240
-    @test_throws ErrorException("labels exhausted, use a larger integer type") label_components!(
-        zeros(UInt8, 260), trues(260); dims=()
-    )
-    @test label_components!(zeros(UInt16, 260), trues(260); dims=()) == 1:260
+                label = similar(A, Int)
+                label_components!(label, A)
+                @test label_components(A) == label
+                label_components!(label, A; r=2, dims=1)
+                @test label_components(A; r=2, dims=1) == label
+                label_components!(label, A, strel_box((3, 3)))
+                @test label_components(A, strel_box((3, 3))) == label
+
+                Ac = complement.(A)
+                @test label_components(Ac; bkg=oneunit(T)) == label_components(A; bkg=zero(T))
+            end
+
+            A = rand(Bool, 11, 11)
+            se = strel(CartesianIndex, centered(Bool[1 1 1; 1 1 0; 0 0 0]))
+            label = @suppress_err label_components(A, se) # deprecated usage in v0.4
+            @test label == label_components(A, strel_box((3, 3)))
+
+            msg = "Non-symmetric structuring element is not supported yet"
+            se = centered(Bool[1 1 1; 1 1 1; 1 1 0])
+            @test_throws ArgumentError(msg) label_components(rand(Bool, 5, 5), se)
+
+            msg = "axes of input and output must match, got (Base.OneTo(11), Base.OneTo(11)) and (-1:1, -1:1). The second argument seems to be a structuring element, it is expected to be the input array."
+            @test_throws DimensionMismatch(msg) label_components!(rand(Bool, 11, 11), strel_diamond((3, 3)))
+
+            msg = "labels exhausted, use a larger integer type"
+            @test_throws ErrorException(msg) label_components!(zeros(Bool, 4, 4), rand(4, 4))
+        end
+
+        A = [
+            true  true  false true
+            true  false true  true
+        ]
+        lbltarget = [
+            1 1 0 2
+            1 0 2 2
+        ]
+        lbltarget1 = [
+            1 2 0 4
+            1 0 3 4
+        ]
+        @test label_components(A) == lbltarget
+        @test label_components(A; dims=:) == lbltarget
+        @test label_components(A; dims=1) == lbltarget1
+        connectivity = centered([
+            false true  false
+            true  false true
+            false true  false
+        ])
+        @test label_components(A, connectivity) == lbltarget
+        connectivity = centered(trues(3, 3))
+        lbltarget2 = [
+            1 1 0 1
+            1 0 1 1
+        ]
+        @test label_components(A, connectivity) == lbltarget2
+    end
+
+    @testset "traits" begin
+        A = [
+            true  true  false true
+            true  false true  true
+        ]
+        label = label_components(A)
+        @test component_boxes(label) ==
+            Vector{Tuple}[[(1, 2), (2, 3)], [(1, 1), (2, 2)], [(1, 3), (2, 4)]]
+        @test component_lengths(label) == [2, 3, 3]
+        @test component_indices(label) == Array{Int}[[4, 5], [1, 2, 3], [6, 7, 8]]
+        @test component_subscripts(label) ==
+            Array{Tuple}[[(2, 2), (1, 3)], [(1, 1), (2, 1), (1, 2)], [(2, 3), (1, 4), (2, 4)]]
+        @test @inferred(component_centroids(label)) ==
+            Tuple[(1.5, 2.5), (4 / 3, 4 / 3), (5 / 3, 11 / 3)]
+
+        @test label_components!(zeros(UInt8, 240), trues(240); dims=()) == 1:240
+        @test_throws ErrorException("labels exhausted, use a larger integer type") label_components!(
+            zeros(UInt8, 260), trues(260); dims=()
+        )
+        @test label_components!(zeros(UInt16, 260), trues(260); dims=()) == 1:260
+    end
+
 end

--- a/test/connected.jl
+++ b/test/connected.jl
@@ -63,14 +63,49 @@
         @test label_components(A, connectivity) == lbltarget2
     end
 
+    @testset "component_boxes" begin
+        A = rand(0:5, 11, 11)
+        label = label_components(A, strel_box((5, 5)))
+        boxes = component_boxes(label)
+        @test eltype(boxes) <: CartesianIndices
+        @test axes(boxes) == (0:maximum(label),)
+
+        # the bounding box is the smallest region that contains the label value
+        @test all(eachindex(boxes)) do i
+            n1 = count(isequal(i), label[boxes[i]])
+            n2 = count(isequal(i), label)
+            n1 == n2
+        end
+
+        A = [2 2 2 2 2; 1 1 1 0 1; 1 0 2 1 1; 1 1 2 2 2; 1 0 2 2 2]
+        label = label_components(A)
+        boxes = component_boxes(label)
+        @test boxes == OffsetArray(
+            [
+                CartesianIndices((2:5, 2:4)),
+                CartesianIndices((1:1, 1:5)),
+                CartesianIndices((2:5, 1:3)),
+                CartesianIndices((3:5, 3:5)),
+                CartesianIndices((2:3, 4:5)),
+            ], -1)
+        @test A[boxes[1]] == [2 2 2 2 2]
+        @test A[boxes[4]] == [0 1; 1 1]
+
+        label = zeros(Int, 5, 5)
+        label[1] = -1
+        msg = "The input labeled array should contain background label `0` as the minimum value"
+        @test_throws ArgumentError(msg) component_boxes(label)
+
+        boxes = component_boxes(ones(Int, 5, 5))
+        @test length(boxes) == 1
+    end
+
     @testset "traits" begin
         A = [
             true  true  false true
             true  false true  true
         ]
         label = label_components(A)
-        @test component_boxes(label) ==
-            Vector{Tuple}[[(1, 2), (2, 3)], [(1, 1), (2, 2)], [(1, 3), (2, 4)]]
         @test component_lengths(label) == [2, 3, 3]
         @test component_indices(label) == Array{Int}[[4, 5], [1, 2, 3], [6, 7, 8]]
         @test component_subscripts(label) ==

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,15 +1,3 @@
-@testset "label_components" begin
-    A = [
-        true  true  false true
-        true  false true  true
-    ]
-    lbltarget1 = [
-        1 2 0 4
-        1 0 3 4
-    ]
-    @test label_components(A, [1]) == lbltarget1
-end
-
 @testset "Feature transform/Anisotropic images" begin
     function ind2cart(F)
         s = CartesianIndices(axes(F))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ImageMorphology
 using ImageCore
+using ImageCore.PaddedViews
 using Test
 using OffsetArrays
 using ImageMetadata

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Suppressor
 @test isempty(detect_ambiguities(ImageMorphology))
 
 using Documenter
-Base.VERSION >= v"1.6" && doctest(ImageMorphology; manual=false)
+Base.VERSION >= v"1.8" && doctest(ImageMorphology; manual=false)
 
 include("testutils.jl")
 @testset "ImageMorphology" begin

--- a/test/structuring_element.jl
+++ b/test/structuring_element.jl
@@ -133,6 +133,7 @@ end
         @test se == centered(Bool[0 1 0; 1 1 1; 0 1 0])
         @test se == strel_diamond((3, 3), (1, 2); r=1)
         @test se == strel_diamond(img, (1, 2); r=1)
+        @test se == strel_diamond(img, :) == strel_diamond(img, (:,))
 
         se = @inferred strel_diamond(img, (1,))
         @test se == @inferred strel_diamond(img, 1)
@@ -216,6 +217,7 @@ end
         @test eltype(se) == Bool
         @test se == centered(Bool[1 1 1; 1 1 1; 1 1 1])
         @test se == strel_box(img; r=1)
+        @test se == strel_box(img, :) == strel_box(img, (:,))
 
         se = @inferred strel_box(img, (1,))
         @test se == @inferred strel_box((3, 1), (1,))


### PR DESCRIPTION
This PR revisits the `src/connected.jl` file and brings a few upgrades and breaking changes. -- mainly to adopt the new SE support.

Enhancements:

- `label_components` now supports generic (symmetric) SE -- this cleaned up some old codes
- documentation and tests are extended
- for `component_boxes`, `component_indices`, `component_subscripts`, `component_lengths` and `component_centeroids`
  - relax type annotation from `AbstractArray{Int}` to `AbstractArray{<:Integer}`
  - robust wrt weird edge cases

Breaking changes:
- `component_boxes` now returns 0-based indexing vector of `CartesianIndices`
- `component_indices`, `component_subscripts`, `component_lengths` and `component_centeroids` now returns 0-based indexing

