### PR TITLE
bugfix: disable extreme_filter tturbo on 32bit

### DIFF
--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -256,9 +256,19 @@ function _extreme_filter_diamond_2D!(f::MAX_OR_MIN, out, A, iter)
     # applying radius=r filter is equivalent to applying radius=1 filter iter times
     for i in 1:iter
         Rx, Ry = (ox + 1):(size(src, 1) + ox - 2), (oy + 1):(size(src, 2) + oy - 2)
-        @tturbo warn_check_args = false for y in Ry, x in Rx
-            tmp = f(f(src[x, y], src[x - 1, y]), src[x + 1, y])
-            out[x, y] = f(f(tmp, src[x, y - 1]), src[x, y + 1])
+        @static if Sys.WORD_SIZE == 64
+            @tturbo warn_check_args = false for y in Ry, x in Rx
+                tmp = f(f(src[x, y], src[x - 1, y]), src[x + 1, y])
+                out[x, y] = f(f(tmp, src[x, y - 1]), src[x, y + 1])
+            end
+        else
+            # FIXME(johnnychen94): doesn't support 32bit machine and it would otherwise
+            # throw the following error if using `@turbo` (#98)
+            # LLVM ERROR: Do not know how to expand the result of this operator!
+            @fastmath @inbounds for y in Ry, x in Rx
+                tmp = f(f(src[x, y], src[x - 1, y]), src[x + 1, y])
+                out[x, y] = f(f(tmp, src[x, y - 1]), src[x, y + 1])
+            end
         end
 
         @inbounds for p in EdgeIterator(R, R_inner)


### PR DESCRIPTION
#92 seems to be problematic on 32bit machines. (#98)

Unless we can reliably make it work, it's better to turn it off for now.

closes #98