### PR TITLE
fix deployment of docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ pages = Any[
 
 makedocs(;
     modules=[ImageMorphology, OffsetArrays],
-    format=Documenter.HTML(; prettyurls, assets, size_threshold=300_000_000),  # mreconstruct has a GIF
+    format=Documenter.HTML(; prettyurls, assets, size_threshold=1_000_000),
     sitename="ImageMorphology",
     pages,
 	checkdocs=:exports,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ assets = Any[demo_assets]
 
 pages = Any[
     "index.md",
-    "Concepts" => Any["structuring_element.md"],
+    "structuring_element.md",
     operators,
     "reference.md"
 ]

--- a/docs/operators/operators/mreconstruct.jl
+++ b/docs/operators/operators/mreconstruct.jl
@@ -12,7 +12,7 @@ using ImageMorphology
 using TestImages
 using ImageBase
 using ImageShow
-using IndirectArrays #hide
+using IndirectArrays, FileIO #hide
 
 img = Gray.(testimage("blob"))
 nothing #hide
@@ -77,7 +77,12 @@ end #hide
 outs = my_reconstruct_outs(marker, mask) #hide
 orders = Dict(x => i for (i, x) in enumerate(sort(mapreduce(unique, union, outs)))) #hide
 colormap = ImageCore.Colors.distinguishable_colors(length(orders)) #hide
-gif = ImageShow.gif([mosaic(frame, with_color(frame, orders, colormap); nrow=1) for frame in outs]; fps=5) #hide
+f = scaleminmax(RGB, 0, 1) #hide
+save("assets/mreconstruct.gif",  #hide
+     f.(cat([mosaic(frame, with_color(frame, orders, colormap); nrow=1) #hide
+             for frame in (@view outs[1:1:end])]..., dims=3)); #hide
+     fps=5) #hide
+# ![alternative text](assets/mreconstruct.gif)
 
 # This is how reconstruction happends and why it is called so -- it reconstructs the
 # `marker` image with a reference image `mask`, this helps us investigate certain properties


### PR DESCRIPTION
this should fix  https://github.com/JuliaImages/ImageMorphology.jl/actions/runs/14154017685/job/39650851454

see https://github.com/JuliaImages/ImageMorphology.jl/pull/137#issuecomment-2764450173

i also got rid of the "Concepts" section in the docs since it only had one sub-section for "Structuring Element", and moved the latter up to the top-level.  i would similarly like to do the same for the "Morphological Operators" section since it only has an "Operators" sub-section, but don't know how to do that with DemoCards.jl.

@johnnychen94 , can you perhaps provide guidance?