### PR TITLE
Bump DataStructures compat to 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 
 [compat]
-DataStructures = "0.17.11, 0.18"
+DataStructures = "0.19"
 Documenter = "0.24, 0.25, 0.26, 0.27"
 ImageCore = "0.9, 0.10"
 LoopVectorization = "0.12"

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -1,6 +1,6 @@
 module ImageMorphology
 
-using DataStructures: Queue, enqueue!, dequeue!
+using DataStructures: Queue
 using ImageCore
 using ImageCore: GenericGrayImage, MappedArrays, FixedPointNumbers
 using OffsetArrays

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -512,10 +512,10 @@ function _generic_naive_labeling!(out, img, se, can_be_labelled=(x) -> true, is_
             # mark point as visited
             @inbounds visited[i] = true
             @inbounds out[i] = curr_label
-            enqueue!(propagationfront, i)
+            push!(propagationfront, i)
             while !isempty(propagationfront)
                 #get indice from propagationfront
-                idx_front = dequeue!(propagationfront)
+                idx_front = popfirst!(propagationfront)
                 # get value at current point
                 @inbounds centervalue = img[idx_front]
                 if can_be_labelled(centervalue) # eg could be specialize for no background
@@ -528,7 +528,7 @@ function _generic_naive_labeling!(out, img, se, can_be_labelled=(x) -> true, is_
                             if is_connected(nl_value, centervalue)
                                 # yes, propagate the "connected" zones to this pixel
                                 @inbounds if !visited[ii]
-                                    enqueue!(propagationfront, ii)
+                                    push!(propagationfront, ii)
                                     # mark it as visited
                                     visited[ii] = true
                                     #propagate label

--- a/src/leveling.jl
+++ b/src/leveling.jl
@@ -1,6 +1,6 @@
 import Base.isless
 import Base.isgreater
-import DataStructures.PriorityQueue, DataStructures.enqueue!, DataStructures.dequeue_pair!
+import DataStructures.PriorityQueue, DataStructures.dequeue_pair!
 
 """
     low_leveling(op, marker, mask; [dims])
@@ -66,7 +66,7 @@ function _low_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marker
             end
             if @inbounds current_max != out[i]
                 out[i] = min(ref[i], current_max)
-                enqueue!(pq, i, out[i])
+                push!(pq, i, out[i])
             end
             # else posponed to the end
         end
@@ -159,7 +159,7 @@ function _high_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marke
             end
             if @inbounds current_min != out[i]
                 out[i] = max(ref[i], current_min)
-                enqueue!(pq, i, out[i])
+                push!(pq, i, out[i])
             end
             # else posponed to the end
         end

--- a/src/leveling.jl
+++ b/src/leveling.jl
@@ -66,7 +66,7 @@ function _low_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marker
             end
             if @inbounds current_max != out[i]
                 out[i] = min(ref[i], current_max)
-                push!(pq, i, out[i])
+                push!(pq, i => out[i])
             end
             # else posponed to the end
         end
@@ -159,7 +159,7 @@ function _high_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marke
             end
             if @inbounds current_min != out[i]
                 out[i] = max(ref[i], current_min)
-                push!(pq, i, out[i])
+                push!(pq, i => out[i])
             end
             # else posponed to the end
         end

--- a/src/leveling.jl
+++ b/src/leveling.jl
@@ -1,6 +1,6 @@
 import Base.isless
 import Base.isgreater
-import DataStructures.PriorityQueue, DataStructures.dequeue_pair!
+import DataStructures.PriorityQueue
 
 """
     low_leveling(op, marker, mask; [dims])
@@ -73,7 +73,7 @@ function _low_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marker
     end
     # Loop until all pixel have been examined 
     while !isempty(pq)
-        curr_idx, _ = dequeue_pair!(pq)
+        curr_idx, _ = popfirst!(pq)
         for Δi in se # examine neighborhoods
             ii = curr_idx + Δi
             if checkbounds(Bool, R, ii) #check that we are in the image
@@ -166,7 +166,7 @@ function _high_leveling!(out::AbstractArray{T,N}, ref::AbstractArray{T,N}, marke
     end
     # Loop until all pixel have been examined 
     while !isempty(pq)
-        curr_idx, _ = dequeue_pair!(pq)
+        curr_idx, _ = popfirst!(pq)
         for Δi in se # examine neighborhoods
             ii = curr_idx + Δi
             if checkbounds(Bool, R, ii) #check that we are in the image


### PR DESCRIPTION
This moves up to DataStructures 0.19, which means replacing `enqueue` and `dequeue` with `push!` and `popfirst!`. That means it can't be compatible with DS 0.18, unfortunately.