### PR TITLE
Make use of LoopVectorization.jl Opt-In

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageMorphology"
 uuid = "787d08f9-d448-5407-9aad-5290dd7ab264"
-version = "0.5.0"
+version = "0.4.7"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageMorphology"
 uuid = "787d08f9-d448-5407-9aad-5290dd7ab264"
-version = "0.4.7"
+version = "0.5.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -10,6 +10,14 @@ LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
+
+[weakdeps]
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+
+[extensions]
+LoopVectorizationExt = "LoopVectorization"
+ImageMetadataExt = "ImageMetadata"
 
 [compat]
 DataStructures = "0.19"
@@ -24,9 +32,10 @@ julia = "1.6"
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "ImageMetadata", "OffsetArrays", "Suppressor", "Test"]
+test = ["Documenter", "ImageMetadata", "LoopVectorization", "OffsetArrays", "Suppressor", "Test"]

--- a/ext/ImageMetadataExt/ImageMetadataExt.jl
+++ b/ext/ImageMetadataExt/ImageMetadataExt.jl
@@ -1,0 +1,13 @@
+module ImageMetadataExt
+    using ImageMorphology, ImageMetadata
+
+    # morphological operations for ImageMeta
+    function ImageMorphology.dilate(img::ImageMetadata.ImageMeta; kwargs...)
+        out = dilate!(similar(ImageMetadata.arraydata(img)), img; kwargs...)
+        return ImageMetadata.shareproperties(img, out)
+    end
+    function ImageMorphology.erode(img::ImageMetadata.ImageMeta; kwargs...)
+        out = erode!(similar(ImageMetadata.arraydata(img)), img; kwargs...)
+        return ImageMetadata.shareproperties(img, out)
+    end
+end

--- a/ext/LoopVectorizationExt/LoopVectorizationExt.jl
+++ b/ext/LoopVectorizationExt/LoopVectorizationExt.jl
@@ -1,0 +1,298 @@
+module LoopVectorizationExt
+
+using ImageMorphology, LoopVectorization
+
+using ImageCore
+using OffsetArrays
+
+
+function __init__()
+    # let the system know that we can opt-in to use LoopVectorization accelerations by default
+    ImageMorphology.USE_SIMD[] = true
+end
+
+@static if Sys.WORD_SIZE == 64
+    # optimized `extreme_filter` implementation for SEDiamond SE and 2D images
+    # Similar approach could be found in
+    # Žlaus, Danijel & Mongus, Domen. (2018). In-place SIMD Accelerated Mathematical Morphology. 76-79. 10.1145/3206157.3206176.
+    # see https://www.researchgate.net/publication/325480366_In-place_SIMD_Accelerated_Mathematical_Morphology
+    function _extreme_filter_diamond_2D!(f::ImageMorphology.MAX_OR_MIN, out::AbstractArray{T}, A, iter) where {T}
+        @debug "call the AVX-enabled `extreme_filter` implementation for 2D SEDiamond" fname = _extreme_filter_diamond_2D!
+        out_actual = out
+
+        out = OffsetArrays.no_offset_view(out)
+        A = OffsetArrays.no_offset_view(A)
+
+        src = if (out === A) || (iter > 1)
+            # To avoid the result affected by loop order, we need two arrays
+            T.(A)
+        elseif eltype(A) != T
+            # To avoid incorrect result, we need to ensure the eltypes are the same
+            # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
+            T.(A)
+        else
+            A
+        end
+        # NOTE(johnnychen94): we don't need to do `out .= src` here because it is write-only;
+        # all values are generated from the read-only `src`.
+
+        # LoopVectorization currently doesn't understand Gray and N0f8 types, thus we
+        # reinterpret to its raw data type UInt8
+        src = rawview(channelview(src))
+        out = rawview(channelview(out))
+
+        # creating temporaries
+        ySize, xSize = size(A)
+        tmp = similar(out, eltype(out), ySize)
+        tmp2 = similar(tmp)
+        tmp3 = similar(tmp)
+
+        # applying radius=r filter is equivalent to applying radius=1 filter r times
+        for i in 1:iter
+            # NOTE(johnnychen94): this implementation is essentially equivalent to the
+            # following loop. Here we buffer the getindex to further improve the performance
+            # by explicitly introducing SIMD buffers.
+
+            # for y in 2:(size(src, 2) - 1), x in 2:(size(src, 1) - 1)
+            #     tmp = f(f(src[x, y], src[x - 1, y]), src[x + 1, y])
+            #     out[x, y] = f(f(tmp, src[x, y - 1]), src[x, y + 1])
+            # end
+
+            #compute first edge column
+            #translate to clipped connection, x neighborhood of interest, ? neighborhood we don't care, . center
+            # x ?
+            # . x
+            # x ?
+            viewprevious = view(src, :, 1)
+            # dilate/erode col 1
+            _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewprevious)
+            viewnext = view(src, :, 2)
+            viewout = view(out, :, 1)
+            # inf/sup between dilate/erode col 1 0 and col 2
+            LoopVectorization.vmap!(f, viewout, viewnext, tmp2)
+            #next->current
+            viewcurrent = view(src, :, 2)
+            for c in 3:xSize
+                # viewprevious c-2
+                # viewcurrent  c-1
+                # viewnext     c
+                # ? x ?
+                # x . x
+                # ? x ?
+                viewout = view(out, :, c - 1)
+                viewnext = view(src, :, c)
+                # dilate(x-1)/erode(x-1)
+                _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewcurrent)
+                @turbo warn_check_args = false for i in eachindex(viewout, viewprevious, tmp2)
+                    #sup(x-2,dilate(x-1)),inf(x-2,erode(x-1))
+                    #sup(sup(x-2,dilate(x-1),x) || inf(inf(x-2,erode(x-1),x)
+                    viewout[i] = f(f(viewprevious[i], tmp2[i]), viewnext[i])
+                end
+                #current->previous
+                viewprevious = view(src, :, c - 1)
+                #next->current
+                viewcurrent = view(src, :, c)
+            end
+            #end last column
+            #translate to clipped connection
+            # ? x
+            # x .
+            # ? x
+            # dilate/erode col x
+            viewout = view(out, :, xSize)
+            _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewcurrent)
+            LoopVectorization.vmap!(f, viewout, tmp2, viewprevious)
+            if iter > 1 && i < iter
+                src .= out
+            end
+        end
+
+        return out_actual
+    end
+else
+    # FIXME(johnnychen94): unknown segfault happens to 32bit machine
+    # https://github.com/JuliaImages/ImageMorphology.jl/pull/106
+    function _extreme_filter_diamond_2D!(f::ImageMorphology.MAX_OR_MIN, out::AbstractArray, A, iter)
+        return ImageMorphology._extreme_filter_diamond_generic!(f, out, A, strel_diamond(A; r=iter))
+    end
+end
+
+# optimized implementation for SEDiamond -- a typical case of separable filter
+function ImageMorphology._extreme_filter_diamond!(f, out, A, Ω::ImageMorphology.SEDiamondArray{N}, ::Val{true}) where {N}
+    rΩ = strel_size(Ω) .÷ 2
+    if N == 2 && f isa ImageMorphology.MAX_OR_MIN && all(rΩ[1] .== rΩ)
+        iter = rΩ[1]
+        return _extreme_filter_diamond_2D!(f, out, A, iter)
+    else
+        return ImageMorphology._extreme_filter_diamond_generic!(f, out, A, Ω)
+    end
+end
+
+function ImageMorphology._extreme_filter_box!(f, out, A, Ω::ImageMorphology.SEBoxArray{N}, ::Val{true}) where {N}
+    rΩ = strel_size(Ω) .÷ 2
+    if N == 2 && f isa ImageMorphology.MAX_OR_MIN && all(rΩ[1] .== rΩ)
+        iter = rΩ[1]
+        return _extreme_filter_box_2D!(f, out, A, iter)
+    else
+        return ImageMorphology._extreme_filter_generic!(f, out, A, Ω)
+    end
+end
+
+@static if Sys.WORD_SIZE == 64
+    # optimized `extreme_filter` implementation for SEBox SE and 2D images
+    # Similar approach could be found in
+    # Žlaus, Danijel & Mongus, Domen. (2018). In-place SIMD Accelerated Mathematical Morphology. 76-79. 10.1145/3206157.3206176.
+    # see https://www.researchgate.net/publication/325480366_In-place_SIMD_Accelerated_Mathematical_Morphology
+    function _extreme_filter_box_2D!(f::ImageMorphology.MAX_OR_MIN, out::AbstractArray{T}, A, iter) where {T}
+        @debug "call the AVX-enabled `extreme_filter` implementation for 2D SEBox" fname = _extreme_filter_box_2D!
+        out_actual = out
+
+        out = OffsetArrays.no_offset_view(out)
+        A = OffsetArrays.no_offset_view(A)
+
+        src = if (out === A) || (iter > 1)
+            # To avoid the result affected by loop order, we need two arrays
+            T.(A)
+        elseif eltype(A) != T
+            # To avoid incorrect result, we need to ensure the eltypes are the same
+            # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
+            T.(A)
+        else
+            A
+        end
+        # NOTE(johnnychen94): we don't need to do `out .= src` here because it is write-only;
+        # all values are generated from the read-only `src`.
+
+        # LoopVectorization currently doesn't understand Gray and N0f8 types, thus we
+        # reinterpret to its raw data type UInt8
+        src = rawview(channelview(src))
+        out = rawview(channelview(out))
+
+        #creating temporaries
+        ySize, xSize = size(A)
+        tmp = similar(out, eltype(out), ySize)
+        tmp2 = similar(tmp)
+        tmp3 = similar(tmp)
+        tmp4 = similar(tmp)
+        tmp5 = similar(tmp)
+
+        # applying radius=r filter is equivalent to applying radius=1 filter r times
+        for i in 1:iter
+            #compute first edge column
+            #translate to clipped connection, x neighborhood of interest, ? neighborhood we don't care, . center
+            # x x
+            # . x
+            # x x
+            viewprevious = view(src, :, 1)
+            # dilate/erode col 1
+            _unsafe_shift_arith!(f, tmp2, tmp, tmp5, viewprevious)
+            viewnext = view(src, :, 2)
+            viewout = view(out, :, 1)
+            # dilate/erode col 2
+            _unsafe_shift_arith!(f, tmp3, tmp, tmp5, viewnext)
+            #sup(dilate col 1,dilate col 0) or inf(erode col 1,erode col 0)
+            LoopVectorization.vmap!(f, viewout, tmp3, tmp2)
+            #next->current
+            viewcurrent = view(src, :, 2)
+            for c in 3:xSize
+                # Invariant of the loop
+                # temp2 contains dilation/erosion of previous col x-2
+                # temp3 contains dilation/erosion of current col x-1
+                # temp4 contains dilation/erosion of next col ie x
+                # viewprevious c-2
+                # viewcurrent  c-1
+                # viewnext     c
+                # x x x
+                # x . x
+                # x x x
+                viewout = view(out, :, c - 1)
+                viewnext = view(src, :, c)
+                # dilate(x)/erode(x)
+                _unsafe_shift_arith!(f, tmp4, tmp, tmp5, viewnext)
+                @turbo warn_check_args = false for i in eachindex(viewout, tmp4, tmp3, tmp2)
+                    #sup(x-2,dilate(x-1)),inf(x-2,erode(x-1))
+                    #sup(dilate(x-2),dilate(x-1),dilate(y)) or inf(erode(x-2),erode(x-1),erode(x))
+                    viewout[i] = f(f(tmp2[i], tmp3[i]), tmp4[i])
+                end
+                #swap
+                tmp4, tmp3 = tmp3, tmp4
+                tmp4, tmp2 = tmp2, tmp4
+            end
+            #end last column
+            #translate to clipped connection
+            # x x
+            # x .
+            # x x
+            # dilate/erode col x
+            viewout = view(out, :, xSize)
+            _unsafe_shift_arith!(f, tmp4, tmp, tmp5, viewcurrent)
+            LoopVectorization.vmap!(f, viewout, tmp2, tmp3)
+            if iter > 1 && i < iter
+                src .= out
+            end
+        end
+
+        return out_actual
+    end
+else
+    # FIXME(johnnychen94): unknown segfault happens to 32bit machine
+    # https://github.com/JuliaImages/ImageMorphology.jl/pull/106
+    function _extreme_filter_box_2D!(f::ImageMorphology.MAX_OR_MIN, out::AbstractArray, A, iter)
+        return ImageMorphology._extreme_filter_generic!(f, out, A, strel_box(A; r=iter))
+    end
+end
+
+# ptr level optimized implementation for Real types
+# short-circuit all check
+# call LoopVectorization directly
+function _unsafe_shift_arith!(
+    f::ImageMorphology.MAX_OR_MIN,
+    out::AbstractVector,
+    tmp::AbstractVector,
+    tmp2::AbstractVector,
+    A::AbstractVector,
+) #tmp external to reuse external allocation
+    if f === min
+        padd = typemax(eltype(out))
+    else
+        padd = typemin(eltype(out))
+    end
+    N = length(out)
+    #in  src  = [1,2,3,4], padd, N=4
+    #out tmp  = [padd,1,2,3]
+    #out tmp2 = [1,2,3,padd]
+    _unsafe_padded_copyto!(tmp, A, true, N, padd)
+    _unsafe_padded_copyto!(tmp2, A, false, N, padd)
+    @turbo warn_check_args = false for i in eachindex(out, A, tmp, tmp2)
+        out[i] = f(f(A[i], tmp[i]), tmp2[i])
+    end
+    return out
+end
+
+# Shift vector of size N up or down by 1 accorded to dir, pad with v
+const SafeArrayTypes{T,N,NA} = Union{Array{T,N},Base.SubArray{T,N,Array{T,NA}}}
+function _unsafe_padded_copyto!(dest::SafeArrayTypes{T,1}, src::SafeArrayTypes{T,1}, dir, N, v) where {T}
+    # ptr level optimized implementation for Real types
+    # short-circuit all check so unsafe
+    if dir
+        unsafe_store!(pointer(dest), v)
+        unsafe_copyto!(pointer(dest, 2), pointer(src, 1), N - 1)
+    else
+        unsafe_copyto!(pointer(dest, 1), pointer(src, 2), N - 1)
+        unsafe_store!(pointer(dest), v, N)
+    end
+    return dest
+end
+function _unsafe_padded_copyto!(dest::AbstractVector, src::AbstractVector, dir, N, v)
+    if dir
+        dest[begin] = v
+        copyto!(dest, 2, src, 1, N - 1)
+    else
+        dest[end] = v
+        copyto!(dest, 1, src, 2, N - 1)
+    end
+    return dest
+end
+
+
+end

--- a/src/ImageMorphology.jl
+++ b/src/ImageMorphology.jl
@@ -7,8 +7,11 @@ using OffsetArrays
 using OffsetArrays: centered
 using LinearAlgebra
 using TiledIteration: EdgeIterator, SplitAxis, SplitAxes
-using Requires
-using LoopVectorization
+
+# backwards compat for package extensions vs Requires.jl
+if !isdefined(Base, :get_extension)
+    using Requires
+end
 
 const _docstring_se = """
 `se` is the structuring element that defines the neighborhood of the image. See
@@ -18,6 +21,9 @@ and half-size `r` to control the diamond size.
 """
 include("StructuringElements/StructuringElements.jl")
 using .StructuringElements
+
+# flag indicating whether or not to use LoopVectorization for SIMD acceleration - will be triggered when users explicitly load LoopVectorization
+const USE_SIMD = Ref(false)
 
 include("convexhull.jl")
 include("connected.jl")
@@ -149,17 +155,10 @@ export
     regional_minima,
     regional_minima!
 
-function __init__()
-    @require ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
-        # morphological operations for ImageMeta
-        function dilate(img::ImageMetadata.ImageMeta; kwargs...)
-            out = dilate!(similar(ImageMetadata.arraydata(img)), img; kwargs...)
-            return ImageMetadata.shareproperties(img, out)
-        end
-        function erode(img::ImageMetadata.ImageMeta; kwargs...)
-            out = erode!(similar(ImageMetadata.arraydata(img)), img; kwargs...)
-            return ImageMetadata.shareproperties(img, out)
-        end
+@static if !isdefined(Base, :get_extension)
+    function __init__()
+        @require ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49" include("../ext/ImageMetadataExt/ImageMetadataExt.jl")
+        @require LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890" include("../ext/LoopVectorizationExt/LoopVectorizationExt.jl")
     end
 end
 

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -1,8 +1,8 @@
 const MAX_OR_MIN = Union{typeof(max),typeof(min)}
 
 """
-    extreme_filter(f, A; r=1, [dims]) -> out
-    extreme_filter(f, A, Ω) -> out
+    extreme_filter(f, A, use_simd=false; r=1, [dims]) -> out
+    extreme_filter(f, A, Ω, use_simd) -> out
 
 Filter the array `A` using select function `f(x, y)` for each Ω-neighborhood. The name
 "extreme" comes from the fact that typical select function `f` choice is `min` and `max`.
@@ -16,6 +16,10 @@ The Ω-neighborhood is defined by the `dims` or `Ω` argument. The `r` and `dims
 specifies the box shape neighborhood `Ω` using [`strel_box`](@ref). The `Ω` is also known as
 structuring element (SE), it can be either displacement offsets or bool array mask, please
 refer to [`strel`](@ref) for more details.
+
+The argument `use_simd` is used to indicate whether to opt-in for acceleration using 
+LoopVectorization's SIMD capabilities. This will be automatically set to `true` if you are 
+using LoopVectorization in the current setting. Users should not need to specify this manually
 
 # Examples
 

--- a/src/extreme_filter.jl
+++ b/src/extreme_filter.jl
@@ -78,8 +78,8 @@ true
 See also the in-place version [`extreme_filter!`](@ref). Another function in ImageFiltering
 package `ImageFiltering.mapwindow` provides similar functionality.
 """
-extreme_filter(f, A; r=nothing, dims=coords_spatial(A)) = extreme_filter(f, A, strel_box(A, dims; r))
-extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
+extreme_filter(f, A, use_simd::Bool=USE_SIMD[]; r=nothing, dims=coords_spatial(A)) = extreme_filter(f, A, strel_box(A, dims; r), use_simd)
+extreme_filter(f, A, Ω::AbstractArray, use_simd::Bool=USE_SIMD[]) = extreme_filter!(f, similar(A), A, Ω, use_simd)
 
 """
     extreme_filter!(f, out, A; [r], [dims])
@@ -88,20 +88,20 @@ extreme_filter(f, A, Ω::AbstractArray) = extreme_filter!(f, similar(A), A, Ω)
 The in-place version of [`extreme_filter`](@ref) where `out` is the output array that gets
 modified.
 """
-extreme_filter!(f, out, A; r=nothing, dims=coords_spatial(A)) = extreme_filter!(f, out, A, strel_box(A, dims; r))
-function extreme_filter!(f, out, A, Ω)
+extreme_filter!(f, out, A, use_simd::Bool=USE_SIMD[]; r=nothing, dims=coords_spatial(A)) = extreme_filter!(f, out, A, strel_box(A, dims; r), use_simd)
+function extreme_filter!(f, out, A, Ω, use_simd::Bool = USE_SIMD[])
     axes(out) == axes(A) || throw(DimensionMismatch("axes(out) must match axes(A)"))
     require_select_function(f, eltype(A))
-    return _extreme_filter!(strel_type(Ω), f, out, A, Ω)
+    return _extreme_filter!(strel_type(Ω), f, out, A, Ω, use_simd)
 end
 
-_extreme_filter!(::MorphologySE, f, out, A, Ω) = _extreme_filter_generic!(f, out, A, Ω)
-_extreme_filter!(::SEDiamond, f, out, A, Ω) = _extreme_filter_diamond!(f, out, A, Ω)
-function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where {T<:Union{Gray{Bool},Bool}}
+_extreme_filter!(::MorphologySE, f, out, A, Ω, ::Bool) = _extreme_filter_generic!(f, out, A, Ω)
+_extreme_filter!(::SEDiamond, f, out, A, Ω, use_simd::Bool) = _extreme_filter_diamond!(f, out, A, Ω, Val(false))
+function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω, ::Symbol) where {T<:Union{Gray{Bool},Bool}}
     # NOTE(johnnychen94): empirical choice based on benchmark results (intel i9-12900k)
     true_ratio = gray(sum(A) / length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
-    true_ratio == 1 && (out .= true; return out)
-    true_ratio == 0 && (out .= false; return out)
+    true_ratio == 1 && (out.=true; return out)
+    true_ratio == 0 && (out.=false; return out)
     use_bool = prod(strel_size(Ω)) > 9 || (f === max && true_ratio > 0.8) || (f === min && true_ratio < 0.2)
     if use_bool
         return _extreme_filter_bool!(f, out, A, Ω)
@@ -109,29 +109,29 @@ function _extreme_filter!(::MorphologySE, f::MAX_OR_MIN, out, A::AbstractArray{T
         return _extreme_filter_generic!(f, out, A, Ω)
     end
 end
-function _extreme_filter!(::SEDiamond, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where {T<:Union{Gray{Bool},Bool}}
+function _extreme_filter!(::SEDiamond, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω, use_simd::Bool) where {T<:Union{Gray{Bool},Bool}}
     rΩ = strel_size(Ω) .÷ 2
     if ndims(A) == 2 && all(rΩ[1] .== rΩ)
         # super fast implementation and wins in all cases
-        return _extreme_filter_diamond!(f, out, A, Ω)
+        return _extreme_filter_diamond!(f, out, A, Ω, Val(use_simd))
     end
 
     # NOTE(johnnychen94): empirical choice based on benchmark results (intel i9-12900k)
     true_ratio = gray(sum(A) / length(A)) # this usually takes <2% of the time but gives a pretty good hint to do the decision
-    true_ratio == 1 && (out .= true; return out)
-    true_ratio == 0 && (out .= false; return out)
+    true_ratio == 1 && (out.=true; return out)
+    true_ratio == 0 && (out.=false; return out)
     use_bool = (f === max && true_ratio > 0.4) || (f === min && true_ratio < 0.6)
     if use_bool
         return _extreme_filter_bool!(f, out, A, Ω)
     else
-        return _extreme_filter_diamond!(f, out, A, Ω)
+        return _extreme_filter_diamond!(f, out, A, Ω, Val(use_simd))
     end
 end
-function _extreme_filter!(::SEBox, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω) where {T<:Union{Gray{Bool},Bool}}
+function _extreme_filter!(::SEBox, f::MAX_OR_MIN, out, A::AbstractArray{T}, Ω, use_simd::Bool) where {T<:Union{Gray{Bool},Bool}}
     rΩ = strel_size(Ω) .÷ 2
     if ndims(A) == 2 && all(rΩ[1] .== rΩ)
         # super fast implementation and wins in all cases
-        return _extreme_filter_box!(f, out, A, Ω)
+        return _extreme_filter_box!(f, out, A, Ω, Val(use_simd))
     end
 
     return _extreme_filter_bool!(f, out, A, Ω)
@@ -176,14 +176,8 @@ function _extreme_filter_generic!(f, out, A, Ω)
 end
 
 # optimized implementation for SEDiamond -- a typical case of separable filter
-function _extreme_filter_diamond!(f, out, A, Ω::SEDiamondArray{N}) where {N}
-    rΩ = strel_size(Ω) .÷ 2
-    if N == 2 && f isa MAX_OR_MIN && all(rΩ[1] .== rΩ)
-        iter = rΩ[1]
-        return _extreme_filter_diamond_2D!(f, out, A, iter)
-    else
-        return _extreme_filter_diamond_generic!(f, out, A, Ω)
-    end
+function _extreme_filter_diamond!(f, out, A, Ω::SEDiamondArray{N}, ::Val{false}) where {N}
+    return _extreme_filter_diamond_generic!(f, out, A, Ω)
 end
 
 function _extreme_filter_diamond_generic!(f, out, A, Ω::SEDiamondArray)
@@ -243,276 +237,8 @@ end
     return dst
 end
 
-# Shift vector of size N up or down by 1 accorded to dir, pad with v
-const SafeArrayTypes{T,N,NA} = Union{Array{T,N},Base.SubArray{T,N,Array{T,NA}}}
-function _unsafe_padded_copyto!(dest::SafeArrayTypes{T,1}, src::SafeArrayTypes{T,1}, dir, N, v) where {T}
-    # ptr level optimized implementation for Real types
-    # short-circuit all check so unsafe
-    if dir
-        unsafe_store!(pointer(dest), v)
-        unsafe_copyto!(pointer(dest, 2), pointer(src, 1), N - 1)
-    else
-        unsafe_copyto!(pointer(dest, 1), pointer(src, 2), N - 1)
-        unsafe_store!(pointer(dest), v, N)
-    end
-    return dest
-end
-function _unsafe_padded_copyto!(dest::AbstractVector, src::AbstractVector, dir, N, v)
-    if dir
-        dest[begin] = v
-        copyto!(dest, 2, src, 1, N - 1)
-    else
-        dest[end] = v
-        copyto!(dest, 1, src, 2, N - 1)
-    end
-    return dest
-end
-
-# ptr level optimized implementation for Real types
-# short-circuit all check
-# call LoopVectorization directly
-function _unsafe_shift_arith!(
-    f::MAX_OR_MIN,
-    out::AbstractVector,
-    tmp::AbstractVector,
-    tmp2::AbstractVector,
-    A::AbstractVector,
-) #tmp external to reuse external allocation
-    if f === min
-        padd = typemax(eltype(out))
-    else
-        padd = typemin(eltype(out))
-    end
-    N = length(out)
-    #in  src  = [1,2,3,4], padd, N=4
-    #out tmp  = [padd,1,2,3]
-    #out tmp2 = [1,2,3,padd]
-    _unsafe_padded_copyto!(tmp, A, true, N, padd)
-    _unsafe_padded_copyto!(tmp2, A, false, N, padd)
-    @turbo warn_check_args = false for i in eachindex(out, A, tmp, tmp2)
-        out[i] = f(f(A[i], tmp[i]), tmp2[i])
-    end
-    return out
-end
-
-@static if Sys.WORD_SIZE == 64
-    # optimized `extreme_filter` implementation for SEDiamond SE and 2D images
-    # Similar approach could be found in
-    # Žlaus, Danijel & Mongus, Domen. (2018). In-place SIMD Accelerated Mathematical Morphology. 76-79. 10.1145/3206157.3206176.
-    # see https://www.researchgate.net/publication/325480366_In-place_SIMD_Accelerated_Mathematical_Morphology
-    function _extreme_filter_diamond_2D!(f::MAX_OR_MIN, out::AbstractArray{T}, A, iter) where {T}
-        @debug "call the AVX-enabled `extreme_filter` implementation for 2D SEDiamond" fname = _extreme_filter_diamond_2D!
-        out_actual = out
-
-        out = OffsetArrays.no_offset_view(out)
-        A = OffsetArrays.no_offset_view(A)
-
-        src = if (out === A) || (iter > 1)
-            # To avoid the result affected by loop order, we need two arrays
-            T.(A)
-        elseif eltype(A) != T
-            # To avoid incorrect result, we need to ensure the eltypes are the same
-            # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
-            T.(A)
-        else
-            A
-        end
-        # NOTE(johnnychen94): we don't need to do `out .= src` here because it is write-only;
-        # all values are generated from the read-only `src`.
-
-        # LoopVectorization currently doesn't understand Gray and N0f8 types, thus we
-        # reinterpret to its raw data type UInt8
-        src = rawview(channelview(src))
-        out = rawview(channelview(out))
-
-        # creating temporaries
-        ySize, xSize = size(A)
-        tmp = similar(out, eltype(out), ySize)
-        tmp2 = similar(tmp)
-        tmp3 = similar(tmp)
-
-        # applying radius=r filter is equivalent to applying radius=1 filter r times
-        for i in 1:iter
-            # NOTE(johnnychen94): this implementation is essentially equivalent to the
-            # following loop. Here we buffer the getindex to further improve the performance
-            # by explicitly introducing SIMD buffers.
-
-            # for y in 2:(size(src, 2) - 1), x in 2:(size(src, 1) - 1)
-            #     tmp = f(f(src[x, y], src[x - 1, y]), src[x + 1, y])
-            #     out[x, y] = f(f(tmp, src[x, y - 1]), src[x, y + 1])
-            # end
-
-            #compute first edge column
-            #translate to clipped connection, x neighborhood of interest, ? neighborhood we don't care, . center
-            # x ?
-            # . x
-            # x ?
-            viewprevious = view(src, :, 1)
-            # dilate/erode col 1
-            _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewprevious)
-            viewnext = view(src, :, 2)
-            viewout = view(out, :, 1)
-            # inf/sup between dilate/erode col 1 0 and col 2
-            LoopVectorization.vmap!(f, viewout, viewnext, tmp2)
-            #next->current
-            viewcurrent = view(src, :, 2)
-            for c in 3:xSize
-                # viewprevious c-2
-                # viewcurrent  c-1
-                # viewnext     c
-                # ? x ?
-                # x . x
-                # ? x ?
-                viewout = view(out, :, c - 1)
-                viewnext = view(src, :, c)
-                # dilate(x-1)/erode(x-1)
-                _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewcurrent)
-                @turbo warn_check_args = false for i in eachindex(viewout, viewprevious, tmp2)
-                    #sup(x-2,dilate(x-1)),inf(x-2,erode(x-1))
-                    #sup(sup(x-2,dilate(x-1),x) || inf(inf(x-2,erode(x-1),x)
-                    viewout[i] = f(f(viewprevious[i], tmp2[i]), viewnext[i])
-                end
-                #current->previous
-                viewprevious = view(src, :, c - 1)
-                #next->current
-                viewcurrent = view(src, :, c)
-            end
-            #end last column
-            #translate to clipped connection
-            # ? x
-            # x .
-            # ? x
-            # dilate/erode col x
-            viewout = view(out, :, xSize)
-            _unsafe_shift_arith!(f, tmp2, tmp, tmp3, viewcurrent)
-            LoopVectorization.vmap!(f, viewout, tmp2, viewprevious)
-            if iter > 1 && i < iter
-                src .= out
-            end
-        end
-
-        return out_actual
-    end
-else
-    # FIXME(johnnychen94): unknown segfault happens to 32bit machine
-    # https://github.com/JuliaImages/ImageMorphology.jl/pull/106
-    function _extreme_filter_diamond_2D!(f::MAX_OR_MIN, out::AbstractArray, A, iter)
-        return _extreme_filter_diamond_generic!(f, out, A, strel_diamond(A; r=iter))
-    end
-end
-
-function _extreme_filter_box!(f, out, A, Ω::SEBoxArray{N}) where {N}
-    rΩ = strel_size(Ω) .÷ 2
-    if N == 2 && f isa MAX_OR_MIN && all(rΩ[1] .== rΩ)
-        iter = rΩ[1]
-        return _extreme_filter_box_2D!(f, out, A, iter)
-    else
-        return _extreme_filter_generic!(f, out, A, Ω)
-    end
-end
-
-@static if Sys.WORD_SIZE == 64
-    # optimized `extreme_filter` implementation for SEBox SE and 2D images
-    # Similar approach could be found in
-    # Žlaus, Danijel & Mongus, Domen. (2018). In-place SIMD Accelerated Mathematical Morphology. 76-79. 10.1145/3206157.3206176.
-    # see https://www.researchgate.net/publication/325480366_In-place_SIMD_Accelerated_Mathematical_Morphology
-    function _extreme_filter_box_2D!(f::MAX_OR_MIN, out::AbstractArray{T}, A, iter) where {T}
-        @debug "call the AVX-enabled `extreme_filter` implementation for 2D SEBox" fname = _extreme_filter_box_2D!
-        out_actual = out
-
-        out = OffsetArrays.no_offset_view(out)
-        A = OffsetArrays.no_offset_view(A)
-
-        src = if (out === A) || (iter > 1)
-            # To avoid the result affected by loop order, we need two arrays
-            T.(A)
-        elseif eltype(A) != T
-            # To avoid incorrect result, we need to ensure the eltypes are the same
-            # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
-            T.(A)
-        else
-            A
-        end
-        # NOTE(johnnychen94): we don't need to do `out .= src` here because it is write-only;
-        # all values are generated from the read-only `src`.
-
-        # LoopVectorization currently doesn't understand Gray and N0f8 types, thus we
-        # reinterpret to its raw data type UInt8
-        src = rawview(channelview(src))
-        out = rawview(channelview(out))
-
-        #creating temporaries
-        ySize, xSize = size(A)
-        tmp = similar(out, eltype(out), ySize)
-        tmp2 = similar(tmp)
-        tmp3 = similar(tmp)
-        tmp4 = similar(tmp)
-        tmp5 = similar(tmp)
-
-        # applying radius=r filter is equivalent to applying radius=1 filter r times
-        for i in 1:iter
-            #compute first edge column
-            #translate to clipped connection, x neighborhood of interest, ? neighborhood we don't care, . center
-            # x x
-            # . x
-            # x x
-            viewprevious = view(src, :, 1)
-            # dilate/erode col 1
-            _unsafe_shift_arith!(f, tmp2, tmp, tmp5, viewprevious)
-            viewnext = view(src, :, 2)
-            viewout = view(out, :, 1)
-            # dilate/erode col 2
-            _unsafe_shift_arith!(f, tmp3, tmp, tmp5, viewnext)
-            #sup(dilate col 1,dilate col 0) or inf(erode col 1,erode col 0)
-            LoopVectorization.vmap!(f, viewout, tmp3, tmp2)
-            #next->current
-            viewcurrent = view(src, :, 2)
-            for c in 3:xSize
-                # Invariant of the loop
-                # temp2 contains dilation/erosion of previous col x-2
-                # temp3 contains dilation/erosion of current col x-1
-                # temp4 contains dilation/erosion of next col ie x
-                # viewprevious c-2
-                # viewcurrent  c-1
-                # viewnext     c
-                # x x x
-                # x . x
-                # x x x
-                viewout = view(out, :, c - 1)
-                viewnext = view(src, :, c)
-                # dilate(x)/erode(x)
-                _unsafe_shift_arith!(f, tmp4, tmp, tmp5, viewnext)
-                @turbo warn_check_args = false for i in eachindex(viewout, tmp4, tmp3, tmp2)
-                    #sup(x-2,dilate(x-1)),inf(x-2,erode(x-1))
-                    #sup(dilate(x-2),dilate(x-1),dilate(y)) or inf(erode(x-2),erode(x-1),erode(x))
-                    viewout[i] = f(f(tmp2[i], tmp3[i]), tmp4[i])
-                end
-                #swap
-                tmp4, tmp3 = tmp3, tmp4
-                tmp4, tmp2 = tmp2, tmp4
-            end
-            #end last column
-            #translate to clipped connection
-            # x x
-            # x .
-            # x x
-            # dilate/erode col x
-            viewout = view(out, :, xSize)
-            _unsafe_shift_arith!(f, tmp4, tmp, tmp5, viewcurrent)
-            LoopVectorization.vmap!(f, viewout, tmp2, tmp3)
-            if iter > 1 && i < iter
-                src .= out
-            end
-        end
-
-        return out_actual
-    end
-else
-    # FIXME(johnnychen94): unknown segfault happens to 32bit machine
-    # https://github.com/JuliaImages/ImageMorphology.jl/pull/106
-    function _extreme_filter_box_2D!(f::MAX_OR_MIN, out::AbstractArray, A, iter)
-        return _extreme_filter_generic!(f, out, A, strel_box(A; r=iter))
-    end
+function _extreme_filter_box!(f, out, A, Ω::SEBoxArray{N}, ::Val{false}) where {N}
+    return _extreme_filter_generic!(f, out, A, Ω)
 end
 
 # optimized implementation for Bool inputs with max/min select function

--- a/test/extreme_filter.jl
+++ b/test/extreme_filter.jl
@@ -97,30 +97,32 @@
     for (se_gen_func, se_name) in Any[(strel_diamond, "diamond"), (strel_box, "box")]
         test_name = "optimization: $se_name"
         @testset "$test_name" begin
-            # ensure the optimized implementation work equivalently to the generic fallback implementation
-            for T in Any[Bool, Int, N0f8, Gray{N0f8}, Gray{Float64}, Float64]
-                for N in (1, 2, 3)
-                    sz = N == 3 ? (32, 32, 5) : ntuple(_ -> 32, N)
-                    img = T == Int ? rand(1:10, sz...) : rand(T, sz...)
-                    for r in (1, 3)
-                        dims_list = ntuple(i -> ntuple(identity, i), N)
-                        for dims in dims_list
-                            se = se_gen_func(ntuple(_ -> 2r + 1, N), dims)
-                            ref = ImageMorphology._extreme_filter_generic!(max, similar(img), img, se)
-                            out = extreme_filter(max, img, se)
-                            @test out == ref
+            for accelerate_mode ∈ (true, false)
+                # ensure the optimized implementation work equivalently to the generic fallback implementation
+                for T in Any[Bool, Int, N0f8, Gray{N0f8}, Gray{Float64}, Float64]
+                    for N in (1, 2, 3)
+                        sz = N == 3 ? (32, 32, 5) : ntuple(_ -> 32, N)
+                        img = T == Int ? rand(1:10, sz...) : rand(T, sz...)
+                        for r in (1, 3)
+                            dims_list = ntuple(i -> ntuple(identity, i), N)
+                            for dims in dims_list
+                                se = se_gen_func(ntuple(_ -> 2r + 1, N), dims)
+                                ref = ImageMorphology._extreme_filter_generic!(max, similar(img), img, se)
+                                out = extreme_filter(max, img, se, accelerate_mode)
+                                @test out == ref
 
-                            # `maybe_floattype` is used to pre-allocate the output for
-                            # higher level operators (e.g., tophat) to avoid overflow
-                            # behavior. We need to ensure it works correctly.
-                            # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
-                            out = similar(img, ImageMorphology.maybe_floattype(T))
-                            extreme_filter!(max, out, img, se)
-                            @test out == ref
+                                # `maybe_floattype` is used to pre-allocate the output for
+                                # higher level operators (e.g., tophat) to avoid overflow
+                                # behavior. We need to ensure it works correctly.
+                                # https://github.com/JuliaImages/ImageMorphology.jl/issues/104
+                                out = similar(img, ImageMorphology.maybe_floattype(T))
+                                extreme_filter!(max, out, img, se, accelerate_mode)
+                                @test out == ref
 
-                            imgc = centered(img)
-                            outc = extreme_filter(max, imgc, se)
-                            @test outc == centered(out)
+                                imgc = centered(img)
+                                outc = extreme_filter(max, imgc, se, accelerate_mode)
+                                @test outc == centered(out)
+                            end
                         end
                     end
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ImageMorphology
 using ImageCore
 using ImageCore.PaddedViews
+using LoopVectorization
 using Test
 using OffsetArrays
 using ImageMetadata


### PR DESCRIPTION
I had a crack at making a PR to address [this issue](https://github.com/JuliaImages/ImageMorphology.jl/issues/143). 

Basically, for users who don't want to rely on LoopVectorization.jl (my explicit use case was for using this package with PackageCompiler.jl) we put any LoopVectorization-specific code into a package extension. By default, we fall back to "generic" implementations of various extreme filter algorithms, but once the package gets loaded we use the accelerated versions (detected by a flag that gets switched when the package extension gets loaded)

I realise this is slightly breaking as now users have to explicitly load LoopVectorization here, and I'm unsure about the structure/strategy you'd prefer here, but figured it'd be a good starting point!

Happy to discuss and refine as needed :)

**EDIT**: note I also moved the ImageMetadata stuff into an extension to be consistent, but should be backwards compat with Requires.jl